### PR TITLE
Convert img to image, and delete stray latex

### DIFF
--- a/ptx/AbsoluteValueFunctions.ptx
+++ b/ptx/AbsoluteValueFunctions.ptx
@@ -11,7 +11,7 @@
     </p>
 
     <p>
-      <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-1"/>
+      <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-1"></image>
     </p>
 
     <p>
@@ -191,11 +191,11 @@
 
             <li>
               <p>
-                <m>3|2x+1| - 5 = 0</m> \setcounter{HW}{\value{enumi}}
+                <m>3|2x+1| - 5 = 0</m>
               </p>
             </li>
 
-            \setcounter{enumi}{\value{HW}}
+            
 
             <li>
               <p>
@@ -429,7 +429,7 @@
                 <sidebyside>
                   <figure>
                     <caption><m>f(x) = |x|</m>, <m>x \lt  0</m></caption>
-                    <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-2"/>
+                    <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-2"></image>
                   </figure>
 
                   <figure>
@@ -438,7 +438,7 @@
 
                   <figure>
                     <caption><m>f(x)=\lvert x\rvert</m></caption>
-                    <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-4"/>
+                    <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-4"></image>
                   </figure>
                 </sidebyside>
                 </figure>
@@ -522,7 +522,7 @@
                 </me>.
                 <figure xml:id="fig_absvalgr2">
                   <caption><m>g(x) = |x-3|</m></caption>
-                  <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-5"/>
+                  <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-5"></image>
                 </figure>
 
                 Once again,
@@ -538,7 +538,7 @@
 
                 <figure xml:id="fig_absvalgr3">
                   <caption><m>h(x) = |x|-3</m></caption>
-                  <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-6"/>
+                  <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-6"></image>
                 </figure>
 
               </p>
@@ -574,7 +574,7 @@
 
                 <figure xml:id="fig_absvalgr4">
                   <caption><m>i(x) = 4-2|3x+1|</m></caption>
-                  <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-7"/>
+                  <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-7"></image>
                 </figure>
 
                 The domain of <m>i</m> is
@@ -642,7 +642,7 @@
 
         <figure xml:id="fig_absvalgr5">
           <caption><m>f(x) = \lvert x\rvert</m> with three labelled points</caption>
-          <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-8"/>
+          <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-8"></image>
         </figure>
 
         <ol>
@@ -656,7 +656,7 @@
               <m>(0,0)</m> to <m>(3,0)</m> and <m>(1,1)</m> to <m>(4,1)</m>.
               Connecting these points in the classic <q><m>\vee</m></q>
               fashion produces the graph of
-              <m>y = g(x)</m> in <xref ref="fig_absvalgr6">Figure</xref>. <figure xml:id="fig_absvalgr6"> <caption><m>g(x) = |x-3| = f(x-3)</m></caption> <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-10"/> </figure>
+              <m>y = g(x)</m> in <xref ref="fig_absvalgr6">Figure</xref>. <figure xml:id="fig_absvalgr6"> <caption><m>g(x) = |x-3| = f(x-3)</m></caption> <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-10"></image> </figure>
             </p>
           </li>
 
@@ -670,7 +670,7 @@
               <m>(0,0)</m> to <m>(0,-3)</m> and <m>(1,1)</m> to <m>(1,-2)</m>.
               Connecting these points with the <q><m>\vee</m></q>
               shape produces our graph of <m>y=h(x)</m>:
-              see <xref ref="fig_absvalgr7">Figure</xref>. <figure xml:id="fig_absvalgr7"> <caption><m>h(x)=\lvert x\rvert -3 = f(x)-3</m></caption> <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-12"/> </figure>
+              see <xref ref="fig_absvalgr7">Figure</xref>. <figure xml:id="fig_absvalgr7"> <caption><m>h(x)=\lvert x\rvert -3 = f(x)-3</m></caption> <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-12"></image> </figure>
             </p>
           </li>
 
@@ -705,7 +705,7 @@
               and <m>\left(0,1\right)</m> to <m>\left(0, 2\right)</m>.
               Connecting these points with the usual <q><m>\vee</m></q>
               shape produces our graph of
-              <m>y = i(x)</m>. <figure xml:id="fig_absvalgr8"> <caption><m>i(x) = 4-2|3x+1| = -2f(3x+1)+4</m></caption> <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-14"/> </figure>
+              <m>y = i(x)</m>. <figure xml:id="fig_absvalgr8"> <caption><m>i(x) = 4-2|3x+1| = -2f(3x+1)+4</m></caption> <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-14"></image> </figure>
             </p>
           </li>
         </ol>
@@ -778,7 +778,7 @@
 
               <figure xml:id="fig_absvalgr9">
                 <caption><m>f(x) = \dfrac{\lvert x\rvert}{x}</m></caption>
-                <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-15"/>
+                <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-15"></image>
               </figure>
 
               As we found earlier, the domain is <m>(-\infty, 0)\cup(0,\infty)</m>.
@@ -862,7 +862,7 @@
 
         <figure xml:id="fig_absvalgrlast">
           <caption><m>g(x) = \lvert x+2\rvert -\lvert x-3\rvert +1</m></caption>
-          <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-16"/>
+          <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-16"></image>
         </figure>
 
         <p>
@@ -1207,7 +1207,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-18"/>
+          <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-18"></image>
         </p>
       </answer>
     </exercise>
@@ -1259,7 +1259,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-19"/>
+          <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-19"></image>
         </p>
       </answer>
     </exercise>
@@ -1311,7 +1311,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-20"/>
+          <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-20"></image>
         </p>
       </answer>
     </exercise>
@@ -1363,7 +1363,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-21"/>
+          <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-21"></image>
         </p>
       </answer>
     </exercise>
@@ -1417,7 +1417,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-22"/>
+          <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-22"></image>
         </p>
       </answer>
     </exercise>
@@ -1469,7 +1469,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-23"/>
+          <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-23"></image>
         </p>
       </answer>
     </exercise>
@@ -1525,7 +1525,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-24"/>
+          <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-24"></image>
         </p>
       </answer>
     </exercise>
@@ -1581,7 +1581,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-25"/>
+          <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-25"></image>
         </p>
       </answer>
     </exercise>
@@ -1645,7 +1645,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-26"/>
+          <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-26"></image>
         </p>
       </answer>
     </exercise>
@@ -1709,7 +1709,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-27"/>
+          <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-27"></image>
         </p>
       </answer>
     </exercise>
@@ -1779,7 +1779,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-28"/>
+          <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-28"></image>
         </p>
       </answer>
     </exercise>
@@ -1847,7 +1847,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-29"/>
+          <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-29"></image>
         </p>
       </answer>
     </exercise>
@@ -1859,7 +1859,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-17"/>
+          <image source="figures/LinearQuadraticGraphics/AbsoluteValueFunctions-17"></image>
         </p>
       </statement>
       <answer>

--- a/ptx/AlgebraicFunctions.ptx
+++ b/ptx/AlgebraicFunctions.ptx
@@ -70,7 +70,7 @@
     <sidebyside>
       <figure>
         <caption><m>y=\sqrt{x}</m></caption>
-        <img src="figures/FurtherGraphics/AlgebraicFunctions-1"/>
+        <image source="figures/FurtherGraphics/AlgebraicFunctions-1"></image>
       </figure>
 
       <figure>
@@ -79,7 +79,7 @@
 
       <figure>
         <caption><m>y=\sqrt[6]{x}</m></caption>
-        <img src="figures/FurtherGraphics/AlgebraicFunctions-3"/>
+        <image source="figures/FurtherGraphics/AlgebraicFunctions-3"></image>
       </figure>
     </sidebyside>
     </figure>
@@ -103,7 +103,7 @@
     <sidebyside>
       <figure>
         <caption><m>y=\sqrt[3]{x}</m></caption>
-        <img src="figures/FurtherGraphics/AlgebraicFunctions-4"/>
+        <image source="figures/FurtherGraphics/AlgebraicFunctions-4"></image>
       </figure>
 
       <figure>
@@ -112,7 +112,7 @@
 
       <figure>
         <caption><m>y=\sqrt[7]{x}</m></caption>
-        <img src="figures/FurtherGraphics/AlgebraicFunctions-6"/>
+        <image source="figures/FurtherGraphics/AlgebraicFunctions-6"></image>
       </figure>
     </sidebyside>
     </figure>
@@ -326,7 +326,7 @@
 
             <li>
               <p>
-                <m>k(x) = \dfrac{2x}{\sqrt{x^2 - 1}}</m> \setcounter{HW}{\value{enumi}}
+                <m>k(x) = \dfrac{2x}{\sqrt{x^2 - 1}}</m>
               </p>
             </li>
           </ol>
@@ -370,7 +370,7 @@
                   <caption><m>f(x) = 3x\sqrt[3]{2-x}</m></caption>
                   <tabular>
                     <row>
-                      <cell><img src="figures/FurtherGraphics/AlgebraicFunctions-7"/></cell>
+                      <cell><image source="figures/FurtherGraphics/AlgebraicFunctions-7"></image></cell>
                     </row>
                     <row>
                       <cell>Sign diagram for <m>f(x)</m></cell>
@@ -379,7 +379,7 @@
                       <cell></cell>
                     </row>
                     <row>
-                      <cell><img src="figures/FurtherGraphics/Algebraic01"/></cell>
+                      <cell><image source="figures/FurtherGraphics/Algebraic01"></image></cell>
                     </row>
                     <row>
                       <cell>The graph <m>y=f(x)</m></cell>
@@ -414,7 +414,7 @@
                 we need to check to see if <m>x=13</m> is an extraneous solution. (Recall that this means we have produced a candidate which doesn't satisfy the original equation.
                 Do you remember how raising both sides of an equation to an even power could cause this?) We find <m>x=13</m> does check since <m>2-\sqrt[4]{x+3} = 2 - \sqrt[4]{13+3} = 2 - \sqrt[4]{16} = 2 - 2 = 0</m>.
                 Our sign diagram for <m>r</m> is given in <xref ref="fig_algfun4">Figure</xref>. <figure xml:id="fig_algfun4"> <caption>Sign diagram for
-                <m>r(x)=2-\sqrt[4]{x+3}</m></caption> <img src="figures/FurtherGraphics/AlgebraicFunctions-8"/> </figure> We find
+                <m>r(x)=2-\sqrt[4]{x+3}</m></caption> <image source="figures/FurtherGraphics/AlgebraicFunctions-8"></image> </figure> We find
                 <m>2-\sqrt[4]{x+3} \geq 0</m> on <m>[-3,13]</m> so this is the domain of <m>g</m>.
                 To find a sign diagram for <m>g</m>,
                 we look for the zeros of <m>g</m>.
@@ -432,7 +432,7 @@
                 but the <em>complete</em> graph.
                 It is always above or on the <m>x</m>-axis,
                 which verifies our sign diagram:
-                see <xref ref="fig_algfun5">Figure</xref>. <table xml:id="fig_algfun5"> <caption><m>g(x)=\sqrt{2-\sqrt[4]{x+3}}</m></caption> <tabular> <row> <cell><img src="figures/FurtherGraphics/AlgebraicFunctions-9"/></cell> </row> <row> <cell>Sign diagram for <m>g(x)</m></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/FurtherGraphics/Algebraic02"/></cell> </row> <row> <cell>Complete graph of <m>y=g(x)</m></cell> </row> </tabular> </table>
+                see <xref ref="fig_algfun5">Figure</xref>. <table xml:id="fig_algfun5"> <caption><m>g(x)=\sqrt{2-\sqrt[4]{x+3}}</m></caption> <tabular> <row> <cell><image source="figures/FurtherGraphics/AlgebraicFunctions-9"></image></cell> </row> <row> <cell>Sign diagram for <m>g(x)</m></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/FurtherGraphics/Algebraic02"></image></cell> </row> <row> <cell>Complete graph of <m>y=g(x)</m></cell> </row> </tabular> </table>
               </p>
             </li>
 
@@ -461,7 +461,7 @@
                 From this,
           it is hardly surprising that as <m>x \rightarrow \pm \infty</m>,
                 <m>h(x) = \sqrt[3]{\frac{8x}{x+1}} \approx \sqrt[3]{8} =2</m>.
-                The sign diagram and graph for <m>h</m> are given in <xref ref="fig_algfun6">Figure</xref>. <table xml:id="fig_algfun6"> <caption><m>h(x)=\sqrt[3]{\dfrac{8x}{x+1}}</m></caption> <tabular> <row> <cell><img src="figures/FurtherGraphics/AlgebraicFunctions-10"/></cell> </row> <row> <cell>Sign diagram for <m>h(x)</m></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/FurtherGraphics/Algebraic03"/></cell> </row> <row> <cell>Graph of <m>y=h(x)</m></cell> </row> </tabular> </table>
+                The sign diagram and graph for <m>h</m> are given in <xref ref="fig_algfun6">Figure</xref>. <table xml:id="fig_algfun6"> <caption><m>h(x)=\sqrt[3]{\dfrac{8x}{x+1}}</m></caption> <tabular> <row> <cell><image source="figures/FurtherGraphics/AlgebraicFunctions-10"></image></cell> </row> <row> <cell>Sign diagram for <m>h(x)</m></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/FurtherGraphics/Algebraic03"></image></cell> </row> <row> <cell>Graph of <m>y=h(x)</m></cell> </row> </tabular> </table>
               </p>
             </li>
 
@@ -473,7 +473,7 @@
                 Setting <m>r(x) = x^2-1</m>,
                 we find the zeros of <m>r</m> to be <m>x = \pm 1</m>,
                 and we find the sign diagram of <m>r</m> shown in <xref ref="fig_algfun7">Figure</xref>. <figure xml:id="fig_algfun7"> <caption>The sign diagram of
-                <m>r(x)=x^2-1</m></caption> <img src="figures/FurtherGraphics/AlgebraicFunctions-11"/> </figure> We find
+                <m>r(x)=x^2-1</m></caption> <image source="figures/FurtherGraphics/AlgebraicFunctions-11"></image> </figure> We find
                 <m>x^2 - 1 \geq 0</m> for <m>(-\infty, -1] \cup [1, \infty)</m>.
                 To keep the denominator of <m>k(x)</m> away from zero,
                 we set <m>\sqrt{x^2-1} = 0</m>.
@@ -507,7 +507,7 @@
                 and as such <m>k(x) \approx \frac{2x}{-x} = -2</m>.
                 Finally,
           it appears as though the graph of <m>k</m> passes the Horizontal Line Test which means <m>k</m> is one to one and <m>k^{-1}</m> exists.
-                Computing <m>k^{-1}</m> is left as an exercise. <table xml:id="fig_algfun8"> <caption><m>k(x)=\dfrac{2x}{\sqrt{x^2-1}}</m></caption> <tabular> <row> <cell><img src="figures/FurtherGraphics/AlgebraicFunctions-12"/></cell> </row> <row> <cell>Sign diagram for <m>k(x)</m></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/FurtherGraphics/Algebraic04"/></cell> </row> <row> <cell>Graph of <m>y=k(x)</m></cell> </row> </tabular> </table>
+                Computing <m>k^{-1}</m> is left as an exercise. <table xml:id="fig_algfun8"> <caption><m>k(x)=\dfrac{2x}{\sqrt{x^2-1}}</m></caption> <tabular> <row> <cell><image source="figures/FurtherGraphics/AlgebraicFunctions-12"></image></cell> </row> <row> <cell>Sign diagram for <m>k(x)</m></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/FurtherGraphics/Algebraic04"></image></cell> </row> <row> <cell>Graph of <m>y=k(x)</m></cell> </row> </tabular> </table>
               </p>
             </li>
           </ol>
@@ -606,8 +606,8 @@
                 (in red)
                 is below the graph of <m>g</m>
                 (in blue)
-                on <m>\left(-\infty, -3 \sqrt{3}\right)\cup \left(3 \sqrt{3}, \infty\right)</m>. <table xml:id="fig_algfun9"> <caption>Sign diagram and graph for <xref ref="ex_algfun2">Example</xref>.1</caption> <tabular> <row> <cell><img src="figures/FurtherGraphics/AlgebraicFunctions-13"/></cell> </row> <row> <cell>Sign diagram for
-                <m>x^{4/3}-x^{2/3}-6</m></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/FurtherGraphics/Algebraic05"/></cell> </row> <row> <cell>Graphs \color{red} <m>y=f(x)</m> and {\color{blue} <m>y=g(x)</m>}</cell> </row> </tabular> </table> As a point of interest,
+                on <m>\left(-\infty, -3 \sqrt{3}\right)\cup \left(3 \sqrt{3}, \infty\right)</m>. <table xml:id="fig_algfun9"> <caption>Sign diagram and graph for <xref ref="ex_algfun2">Example</xref>.1</caption> <tabular> <row> <cell><image source="figures/FurtherGraphics/AlgebraicFunctions-13"></image></cell> </row> <row> <cell>Sign diagram for
+                <m>x^{4/3}-x^{2/3}-6</m></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/FurtherGraphics/Algebraic05"></image></cell> </row> <row> <cell>Graphs \color{red} <m>y=f(x)</m> and {\color{blue} <m>y=g(x)</m>}</cell> </row> </tabular> </table> As a point of interest,
                 if we take a closer look at the graphs of <m>f</m> and <m>g</m> near <m>x=0</m> with the axes off,
                 we see in <xref ref="fig_algfun10">Figure</xref>
                 that despite the fact they both involve cube roots,
@@ -615,7 +615,7 @@
                 The graph of <m>f</m> has a sharp turn, or cusp,
                 while <m>g</m> does not. (Recall that we introduced this feature on <xref ref="cusppicture">page</xref>
                 as a feature which makes the graph of a function
-                <q>not smooth</q>.) <table xml:id="fig_algfun10"> <caption>The graphs of <m>f</m> and <m>g</m> near <m>x=0</m></caption> <tabular> <row> <cell><img src="figures/FurtherGraphics/Algebraic06"/></cell> </row> <row> <cell><m>y=f(x)</m></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/FurtherGraphics/Algebraic07"/></cell> </row> <row> <cell><m>y=g(x)</m></cell> </row> </tabular> </table>
+                <q>not smooth</q>.) <table xml:id="fig_algfun10"> <caption>The graphs of <m>f</m> and <m>g</m> near <m>x=0</m></caption> <tabular> <row> <cell><image source="figures/FurtherGraphics/Algebraic06"></image></cell> </row> <row> <cell><m>y=f(x)</m></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/FurtherGraphics/Algebraic07"></image></cell> </row> <row> <cell><m>y=g(x)</m></cell> </row> </tabular> </table>
               </p>
             </li>
 
@@ -715,7 +715,7 @@
                 <caption>Sign diagram and graph for <xref ref="ex_algfun2">Example</xref>.2</caption>
                 <tabular>
                   <row>
-                    <cell><img src="figures/FurtherGraphics/AlgebraicFunctions-14"/></cell>
+                    <cell><image source="figures/FurtherGraphics/AlgebraicFunctions-14"></image></cell>
                   </row>
                   <row>
                     <cell>Sign diagram for <m>3(2-x)^{1/3}-x(2-x)^{-2/3}</m></cell>
@@ -724,7 +724,7 @@
                     <cell></cell>
                   </row>
                   <row>
-                    <cell><img src="figures/FurtherGraphics/Algebraic08"/></cell>
+                    <cell><image source="figures/FurtherGraphics/Algebraic08"></image></cell>
                   </row>
                   <row>
                     <cell>Graphs \color{red} <m>y=f(x)</m> and {\color{blue} <m>y=g(x)</m>}</cell>
@@ -757,7 +757,7 @@
 
         <figure xml:id="fig_algfun12">
           <caption>Diagram for <xref ref="SasquatchCable">Example</xref></caption>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-15"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-15"></image>
         </figure>
 
         <ol>
@@ -871,7 +871,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-16"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-16"></image>
         </p>
 
         <p>
@@ -887,7 +887,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-17"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-17"></image>
         </p>
       </answer>
     </exercise>
@@ -907,7 +907,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-18"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-18"></image>
         </p>
 
         <p>
@@ -923,7 +923,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-19"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-19"></image>
         </p>
       </answer>
     </exercise>
@@ -943,7 +943,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-20"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-20"></image>
         </p>
 
         <p>
@@ -959,7 +959,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-21"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-21"></image>
         </p>
       </answer>
     </exercise>
@@ -979,7 +979,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-22"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-22"></image>
         </p>
 
         <p>
@@ -995,7 +995,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-23"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-23"></image>
         </p>
       </answer>
     </exercise>
@@ -1015,7 +1015,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-24"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-24"></image>
         </p>
 
         <p>
@@ -1035,7 +1035,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-25"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-25"></image>
         </p>
       </answer>
     </exercise>
@@ -1055,7 +1055,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-26"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-26"></image>
         </p>
 
         <p>
@@ -1071,7 +1071,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-27"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-27"></image>
         </p>
       </answer>
     </exercise>
@@ -1091,7 +1091,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-28"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-28"></image>
         </p>
 
         <p>
@@ -1106,7 +1106,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-29"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-29"></image>
         </p>
       </answer>
     </exercise>
@@ -1126,7 +1126,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-30"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-30"></image>
         </p>
 
         <p>
@@ -1142,7 +1142,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-31"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-31"></image>
         </p>
       </answer>
     </exercise>
@@ -1162,7 +1162,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-32"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-32"></image>
         </p>
 
         <p>
@@ -1178,7 +1178,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-33"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-33"></image>
         </p>
       </answer>
     </exercise>
@@ -1198,7 +1198,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-34"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-34"></image>
         </p>
 
         <p>
@@ -1213,7 +1213,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-35"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-35"></image>
         </p>
       </answer>
     </exercise>
@@ -1234,7 +1234,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-36"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-36"></image>
         </p>
       </answer>
     </exercise>
@@ -1250,7 +1250,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-37"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-37"></image>
         </p>
       </answer>
     </exercise>
@@ -1266,7 +1266,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-38"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-38"></image>
         </p>
       </answer>
     </exercise>
@@ -1282,7 +1282,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-39"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-39"></image>
         </p>
       </answer>
     </exercise>
@@ -1298,7 +1298,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-40"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-40"></image>
         </p>
       </answer>
     </exercise>
@@ -1314,7 +1314,7 @@
         </p>
 
         <p>
-          <img src="figures/FurtherGraphics/AlgebraicFunctions-41"/>
+          <image source="figures/FurtherGraphics/AlgebraicFunctions-41"></image>
         </p>
       </answer>
     </exercise>
@@ -1725,7 +1725,7 @@
 
           <li>
             <p>
-              The graph is below. <img src="figures/FurtherGraphics/WINDCHILL"/>
+              The graph is below. <image source="figures/FurtherGraphics/WINDCHILL"></image>
             </p>
           </li>
         </ol>
@@ -1946,7 +1946,7 @@
               <m>y \rightarrow \infty</m> which means,
               in this case, Fritzy's pursuit never ends;
               he never catches Chewbacca.
-              This makes sense since Chewbacca has a head start and is running faster than Fritzy. <tabular> <row> <cell><img src="figures/FurtherGraphics/PURSUIT01.jpg"/></cell> <cell><img src="figures/FurtherGraphics/PURSUIT02.jpg"/></cell> </row> <row> <cell><m>y = \frac{1}{3}x^{3/2} - \sqrt{x} + \frac{2}{3}</m></cell> <cell><m>y = \frac{1}{6}x^3+\frac{1}{2x} - \frac{2}{3}</m></cell> </row> </tabular>
+              This makes sense since Chewbacca has a head start and is running faster than Fritzy. <tabular> <row> <cell><image source="figures/FurtherGraphics/PURSUIT01.jpg"></image></cell> <cell><image source="figures/FurtherGraphics/PURSUIT02.jpg"></image></cell> </row> <row> <cell><m>y = \frac{1}{3}x^{3/2} - \sqrt{x} + \frac{2}{3}</m></cell> <cell><m>y = \frac{1}{6}x^3+\frac{1}{2x} - \frac{2}{3}</m></cell> </row> </tabular>
             </p>
           </li>
         </ol>

--- a/ptx/Angles.ptx
+++ b/ptx/Angles.ptx
@@ -18,7 +18,7 @@
 
     <figure xml:id="fig_angles1">
       <caption>A ray with initial point <m>P</m></caption>
-      <img src="figures/IntroTrigGraphics/Angles-1"/>
+      <image source="figures/IntroTrigGraphics/Angles-1"></image>
     </figure>
 
     <p>
@@ -36,8 +36,8 @@
     <sidebyside>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/Angles-2"/></cell>
-          <cell><img src="figures/IntroTrigGraphics/Angles-3"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/Angles-2"></image></cell>
+          <cell><image source="figures/IntroTrigGraphics/Angles-3"></image></cell>
         </row>
         <row>
           <cell>An angle with vertex <m>P</m></cell>
@@ -64,8 +64,8 @@
     <sidebyside>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/Angles-4"/></cell>
-          <cell><img src="figures/IntroTrigGraphics/Angles-5"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/Angles-4"></image></cell>
+          <cell><image source="figures/IntroTrigGraphics/Angles-5"></image></cell>
         </row>
         <row>
           <cell>A straight angle</cell>
@@ -86,13 +86,13 @@
       <caption>Two ways to measure an angle</caption>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/Angles-6"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/Angles-6"></image></cell>
         </row>
         <row>
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/Angles-7"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/Angles-7"></image></cell>
         </row>
       </tabular>
     </table>
@@ -112,7 +112,7 @@
 
     <figure xml:id="fig_angles5">
       <caption>Labelling angles</caption>
-      <img src="figures/IntroTrigGraphics/Angles-8"/>
+      <image source="figures/IntroTrigGraphics/Angles-8"></image>
     </figure>
 
     <aside>
@@ -142,9 +142,9 @@
     <sidebyside>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/Angles-9"/></cell>
-          <cell><img src="figures/IntroTrigGraphics/Angles-10"/></cell>
-          <cell><img src="figures/IntroTrigGraphics/Angles-11"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/Angles-9"></image></cell>
+          <cell><image source="figures/IntroTrigGraphics/Angles-10"></image></cell>
+          <cell><image source="figures/IntroTrigGraphics/Angles-11"></image></cell>
         </row>
         <row>
           <cell>One revolution <m>\leftrightarrow 360^\circ</m></cell>
@@ -180,9 +180,9 @@
     <sidebyside>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/Angles-12"/></cell>
-          <cell><img src="figures/IntroTrigGraphics/Angles-13"/></cell>
-          <cell><img src="figures/IntroTrigGraphics/Angles-14"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/Angles-12"></image></cell>
+          <cell><image source="figures/IntroTrigGraphics/Angles-13"></image></cell>
+          <cell><image source="figures/IntroTrigGraphics/Angles-14"></image></cell>
         </row>
         <row>
           <cell><m>240^\circ</m></cell>
@@ -210,7 +210,7 @@
       <caption>Supplementary and complementary angles</caption>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/Angles-15"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/Angles-15"></image></cell>
         </row>
         <row>
           <cell>Supplementary angles</cell>
@@ -219,7 +219,7 @@
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/Angles-16"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/Angles-16"></image></cell>
         </row>
         <row>
           <cell>Complementary angles</cell>
@@ -266,7 +266,7 @@
       <caption>The sign of an angle</caption>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/Angles-17"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/Angles-17"></image></cell>
         </row>
         <row>
           <cell>A positive angle, <m>45^\circ</m></cell>
@@ -275,7 +275,7 @@
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/Angles-18"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/Angles-18"></image></cell>
         </row>
         <row>
           <cell>A negative angle, <m>-45^\circ</m></cell>
@@ -285,7 +285,7 @@
 
     <figure xml:id="fig_angles10">
       <caption>Angles can comprise more than one revolution</caption>
-      <img src="figures/IntroTrigGraphics/Angles-19"/>
+      <image source="figures/IntroTrigGraphics/Angles-19"></image>
     </figure>
 
     <p>
@@ -330,7 +330,7 @@
 
     <figure xml:id="fig_angles11">
       <caption>Two coterminal angles, <m>\alpha = 120^{\circ}</m> and <m>\beta = -240^{\circ}</m>, in standard position.</caption>
-      <img src="figures/IntroTrigGraphics/Angles-20"/>
+      <image source="figures/IntroTrigGraphics/Angles-20"></image>
     </figure>
 
     <example xml:id="orientedcoterminaldegree">
@@ -384,7 +384,7 @@
                 Substituting <m>k = -1</m> gives <m>\theta = 60^{\circ} - 360^{\circ} = -300^{\circ}</m>.
                 Finally, if we let <m>k = 2</m>,
                 we get <m>\theta = 60^{\circ} + 720^{\circ} = 780^{\circ}</m>:
-                see <xref ref="fig_angles12">Figure</xref>. <figure xml:id="fig_angles12"> <caption><m>\alpha = 60^{\circ}</m> in standard position</caption> <img src="figures/IntroTrigGraphics/Angles-21"/> </figure>
+                see <xref ref="fig_angles12">Figure</xref>. <figure xml:id="fig_angles12"> <caption><m>\alpha = 60^{\circ}</m> in standard position</caption> <image source="figures/IntroTrigGraphics/Angles-21"></image> </figure>
               </p>
             </li>
 
@@ -400,7 +400,7 @@
                 We find <m>135^{\circ}</m>,
                 <m>-585^{\circ}</m> and
           <m>495^{\circ}</m> are all coterminal with <m>-225^{\circ}</m>:
-                see <xref ref="fig_angles13">Figure</xref>. <figure xml:id="fig_angles13"> <caption><m>\beta = -225^{\circ}</m> in standard position</caption> <img src="figures/IntroTrigGraphics/Angles-22"/> </figure> <figure xml:id="fig_angles14"> <caption><m>\gamma = 540^{\circ}</m> in standard position</caption> <img src="figures/IntroTrigGraphics/Angles-23"/> </figure>
+                see <xref ref="fig_angles13">Figure</xref>. <figure xml:id="fig_angles13"> <caption><m>\beta = -225^{\circ}</m> in standard position</caption> <image source="figures/IntroTrigGraphics/Angles-22"></image> </figure> <figure xml:id="fig_angles14"> <caption><m>\gamma = 540^{\circ}</m> in standard position</caption> <image source="figures/IntroTrigGraphics/Angles-23"></image> </figure>
               </p>
             </li>
 
@@ -454,7 +454,7 @@
 
     <figure xml:id="fig_angles15">
       <caption><m>\phi = -750^{\circ}</m> in standard position</caption>
-      <img src="figures/IntroTrigGraphics/Angles-24"/>
+      <image source="figures/IntroTrigGraphics/Angles-24"></image>
     </figure>
 
     <definition xml:id="pidefn">
@@ -510,7 +510,7 @@
 
     <figure xml:id="fig_angles16">
       <caption>The radian measure of <m>\theta</m> is <m>\dfrac{s}{r}</m></caption>
-      <img src="figures/IntroTrigGraphics/Angles-25"/>
+      <image source="figures/IntroTrigGraphics/Angles-25"></image>
     </figure>
 
     <p>
@@ -529,7 +529,7 @@
       <caption>An angle of <m>k</m> radians subtends an arc of length <m>k\cdot r</m></caption>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/Angles-26"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/Angles-26"></image></cell>
         </row>
         <row>
           <cell><m>\alpha</m> has radian measure 1</cell>
@@ -538,7 +538,7 @@
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/Angles-27"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/Angles-27"></image></cell>
         </row>
         <row>
           <cell><m>\beta</m> has radian measure 4</cell>
@@ -634,7 +634,7 @@
                 Substituting <m>k = -1</m> gives
                 <m>\theta = \frac{\pi}{6} - \frac{12 \pi}{6} = -\frac{11 \pi}{6}</m> and when we let <m>k = 2</m>,
                 we get <m>\theta = \frac{\pi}{6} + \frac{24 \pi}{6} = \frac{25 \pi}{6}</m>:
-                see <xref ref="fig_angles18">Figure</xref>. <figure xml:id="fig_angles18"> <caption><m>\alpha = \frac{\pi}{6}</m> in standard position.</caption> <img src="figures/IntroTrigGraphics/Angles-28"/> </figure>
+                see <xref ref="fig_angles18">Figure</xref>. <figure xml:id="fig_angles18"> <caption><m>\alpha = \frac{\pi}{6}</m> in standard position.</caption> <image source="figures/IntroTrigGraphics/Angles-28"></image> </figure>
               </p>
             </li>
 
@@ -649,7 +649,7 @@
                 We obtain <m>\frac{2\pi}{3}</m>,
                 <m>-\frac{10 \pi}{3}</m> and
                 <m>\frac{8 \pi}{3}</m> as coterminal angles:
-                see <xref ref="fig_angles19">Figure</xref>. <figure xml:id="fig_angles19"> <caption><m>\beta=-\frac{4\pi}{3}</m> in standard position.</caption> <img src="figures/IntroTrigGraphics/Angles-29"/> </figure>
+                see <xref ref="fig_angles19">Figure</xref>. <figure xml:id="fig_angles19"> <caption><m>\beta=-\frac{4\pi}{3}</m> in standard position.</caption> <image source="figures/IntroTrigGraphics/Angles-29"></image> </figure>
               </p>
             </li>
 
@@ -666,7 +666,7 @@
                 Working through the arithmetic, we find:
                 <m>\frac{\pi}{4}</m>,
                 <m>-\frac{7 \pi}{4}</m> and <m>\frac{17 \pi}{4}</m>:
-                see <xref ref="fig_angles20">Figure</xref>. <figure xml:id="fig_angles20"> <caption><m>\gamma = \frac{9\pi}{4}</m> in standard position.</caption> <img src="figures/IntroTrigGraphics/Angles-30"/> </figure>
+                see <xref ref="fig_angles20">Figure</xref>. <figure xml:id="fig_angles20"> <caption><m>\gamma = \frac{9\pi}{4}</m> in standard position.</caption> <image source="figures/IntroTrigGraphics/Angles-30"></image> </figure>
               </p>
             </li>
 
@@ -683,7 +683,7 @@
                 To find coterminal angles,
                 we compute <m>\theta = -\frac{5 \pi}{2} + \frac{4 \pi}{2} \cdot k</m> for a few integers <m>k</m> and obtain <m>-\frac{\pi}{2}</m>,
                 <m>\frac{3 \pi}{2}</m> and <m>\frac{7 \pi}{2}</m>:
-                see <xref ref="fig_angles21">Figure</xref>. <figure xml:id="fig_angles21"> <caption><m>\phi = -\frac{5\pi}{2}</m> in standard position.</caption> <img src="figures/IntroTrigGraphics/Angles-31"/> </figure>
+                see <xref ref="fig_angles21">Figure</xref>. <figure xml:id="fig_angles21"> <caption><m>\phi = -\frac{5\pi}{2}</m> in standard position.</caption> <image source="figures/IntroTrigGraphics/Angles-31"></image> </figure>
               </p>
             </li>
           </ol>
@@ -780,9 +780,9 @@
     <sidebyside>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/Angles-32"/></cell>
-          <cell><img src="figures/IntroTrigGraphics/Angles-33"/></cell>
-          <cell><img src="figures/IntroTrigGraphics/Angles-34"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/Angles-32"></image></cell>
+          <cell><image source="figures/IntroTrigGraphics/Angles-33"></image></cell>
+          <cell><image source="figures/IntroTrigGraphics/Angles-34"></image></cell>
         </row>
         <row>
           <cell>On the unit circle, <m>\theta = s</m></cell>
@@ -832,7 +832,7 @@
                 The arc associated with
           <m>t = \frac{3 \pi}{4}</m> is the arc on the Unit Circle which subtends the angle <m>\frac{3 \pi}{4}</m> in radian measure.
                 Since <m>\frac{3 \pi}{4}</m> is <m>\frac{3}{8}</m> of a revolution,
-                we have an arc which begins at the point <m>(1,0)</m> proceeds counter-clockwise up to midway through Quadrant II: see <xref ref="fig_angles20">Figure</xref>. <figure xml:id="fig_angles22"> <caption><m>t=\frac{3\pi}{4}</m></caption> <img src="figures/IntroTrigGraphics/Angles-35"/> </figure>
+                we have an arc which begins at the point <m>(1,0)</m> proceeds counter-clockwise up to midway through Quadrant II: see <xref ref="fig_angles20">Figure</xref>. <figure xml:id="fig_angles22"> <caption><m>t=\frac{3\pi}{4}</m></caption> <image source="figures/IntroTrigGraphics/Angles-35"></image> </figure>
               </p>
             </li>
 
@@ -842,7 +842,7 @@
                 and <m>t=-2\pi</m> is negative,
                 we graph the arc which begins at <m>(1,0)</m> and proceeds
                 <em>clockwise</em> for one full revolution:
-                see <xref ref="fig_angles20">Figure</xref>. <figure xml:id="fig_angles23"> <caption><m>t=-2\pi</m></caption> <img src="figures/IntroTrigGraphics/Angles-36"/> </figure>
+                see <xref ref="fig_angles20">Figure</xref>. <figure xml:id="fig_angles23"> <caption><m>t=-2\pi</m></caption> <image source="figures/IntroTrigGraphics/Angles-36"></image> </figure>
               </p>
             </li>
 
@@ -853,7 +853,7 @@
                 Since <m>\pi \approx 3.14</m> and <m>\frac{\pi}{2} \approx 1.57</m>,
                 we find that rotating <m>2</m> radians clockwise from the point <m>(1,0)</m> lands us in Quadrant III. To more accurately place the endpoint,
                 we successively halve the angle measure until we find
-                <m>\frac{5 \pi}{8} \approx 1.96</m> which tells us our arc extends just a bit beyond the quarter mark into Quadrant III: see <xref ref="fig_angles20">Figure</xref>. <figure xml:id="fig_angles24"> <caption><m>t=-2</m></caption> <img src="figures/IntroTrigGraphics/Angles-37"/> </figure>
+                <m>\frac{5 \pi}{8} \approx 1.96</m> which tells us our arc extends just a bit beyond the quarter mark into Quadrant III: see <xref ref="fig_angles20">Figure</xref>. <figure xml:id="fig_angles24"> <caption><m>t=-2</m></caption> <image source="figures/IntroTrigGraphics/Angles-37"></image> </figure>
               </p>
             </li>
 
@@ -887,12 +887,12 @@
 
     <figure xml:id="fig_angles25">
       <caption><m>t=117</m></caption>
-      <img src="figures/IntroTrigGraphics/Angles-38"/>
+      <image source="figures/IntroTrigGraphics/Angles-38"></image>
     </figure>
 
     <figure xml:id="fig_angles26">
       <caption>Circular motion</caption>
-      <img src="figures/IntroTrigGraphics/Angles-39"/>
+      <image source="figures/IntroTrigGraphics/Angles-39"></image>
     </figure>
 
     <p>
@@ -1030,7 +1030,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-41"/>
+          <image source="figures/IntroTrigGraphics/Angles-41"></image>
         </p>
       </answer>
     </exercise>
@@ -1050,7 +1050,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-42"/>
+          <image source="figures/IntroTrigGraphics/Angles-42"></image>
         </p>
       </answer>
     </exercise>
@@ -1070,7 +1070,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-43"/>
+          <image source="figures/IntroTrigGraphics/Angles-43"></image>
         </p>
       </answer>
     </exercise>
@@ -1090,7 +1090,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-44"/>
+          <image source="figures/IntroTrigGraphics/Angles-44"></image>
         </p>
       </answer>
     </exercise>
@@ -1110,7 +1110,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-45"/>
+          <image source="figures/IntroTrigGraphics/Angles-45"></image>
         </p>
       </answer>
     </exercise>
@@ -1130,7 +1130,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-46"/>
+          <image source="figures/IntroTrigGraphics/Angles-46"></image>
         </p>
       </answer>
     </exercise>
@@ -1150,7 +1150,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-47"/>
+          <image source="figures/IntroTrigGraphics/Angles-47"></image>
         </p>
       </answer>
     </exercise>
@@ -1170,7 +1170,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-48"/>
+          <image source="figures/IntroTrigGraphics/Angles-48"></image>
         </p>
       </answer>
     </exercise>
@@ -1190,7 +1190,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-49"/>
+          <image source="figures/IntroTrigGraphics/Angles-49"></image>
         </p>
       </answer>
     </exercise>
@@ -1210,7 +1210,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-50"/>
+          <image source="figures/IntroTrigGraphics/Angles-50"></image>
         </p>
       </answer>
     </exercise>
@@ -1230,7 +1230,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-51"/>
+          <image source="figures/IntroTrigGraphics/Angles-51"></image>
         </p>
       </answer>
     </exercise>
@@ -1250,7 +1250,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-52"/>
+          <image source="figures/IntroTrigGraphics/Angles-52"></image>
         </p>
       </answer>
     </exercise>
@@ -1270,7 +1270,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-53"/>
+          <image source="figures/IntroTrigGraphics/Angles-53"></image>
         </p>
       </answer>
     </exercise>
@@ -1290,7 +1290,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-54"/>
+          <image source="figures/IntroTrigGraphics/Angles-54"></image>
         </p>
       </answer>
     </exercise>
@@ -1310,7 +1310,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-55"/>
+          <image source="figures/IntroTrigGraphics/Angles-55"></image>
         </p>
       </answer>
     </exercise>
@@ -1330,7 +1330,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-56"/>
+          <image source="figures/IntroTrigGraphics/Angles-56"></image>
         </p>
       </answer>
     </exercise>
@@ -1350,7 +1350,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-57"/>
+          <image source="figures/IntroTrigGraphics/Angles-57"></image>
         </p>
       </answer>
     </exercise>
@@ -1370,7 +1370,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-58"/>
+          <image source="figures/IntroTrigGraphics/Angles-58"></image>
         </p>
       </answer>
     </exercise>
@@ -1390,7 +1390,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-59"/>
+          <image source="figures/IntroTrigGraphics/Angles-59"></image>
         </p>
       </answer>
     </exercise>
@@ -1410,7 +1410,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-60"/>
+          <image source="figures/IntroTrigGraphics/Angles-60"></image>
         </p>
       </answer>
     </exercise>
@@ -1631,7 +1631,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-61"/>
+          <image source="figures/IntroTrigGraphics/Angles-61"></image>
         </p>
       </answer>
     </exercise>
@@ -1648,7 +1648,7 @@
       </answer>
     </exercise>
     <p>
-      <img src="figures/IntroTrigGraphics/Angles-62"/>
+      <image source="figures/IntroTrigGraphics/Angles-62"></image>
     </p>
     <exercise>
       <statement>
@@ -1662,7 +1662,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-63"/>
+          <image source="figures/IntroTrigGraphics/Angles-63"></image>
         </p>
       </answer>
     </exercise>
@@ -1678,7 +1678,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-64"/>
+          <image source="figures/IntroTrigGraphics/Angles-64"></image>
         </p>
       </answer>
     </exercise>
@@ -1694,7 +1694,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/Angles-65"/>
+          <image source="figures/IntroTrigGraphics/Angles-65"></image>
         </p>
       </answer>
     </exercise>
@@ -1795,7 +1795,7 @@
 
         <p>
           (Hint: Use the proportion
-          <m>\frac{A}{\text{ area of the circle } } = \frac{s}{\text{ circumference of the circle } }</m>.) <img src="figures/IntroTrigGraphics/Angles-40"/>
+          <m>\frac{A}{\text{ area of the circle } } = \frac{s}{\text{ circumference of the circle } }</m>.) <image source="figures/IntroTrigGraphics/Angles-40"></image>
         </p>
       </statement>
     </exercise>

--- a/ptx/ArcTrig.ptx
+++ b/ptx/ArcTrig.ptx
@@ -61,7 +61,7 @@
       <caption>Reflecting <m>y=\cos(x)</m> across <m>y=x</m> yields <m>y=\arccos(x)</m></caption>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/ArcTrig-2"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/ArcTrig-2"></image></cell>
         </row>
         <row>
           <cell><m>f(x) = \cos(x)</m>, <m>0 \leq x \leq \pi</m></cell>
@@ -70,7 +70,7 @@
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/ArcTrig-3"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/ArcTrig-3"></image></cell>
         </row>
         <row>
           <cell><m>f^{-1}(x) = \arccos(x)</m></cell>
@@ -198,7 +198,7 @@
       <caption>Reflecting <m>y=\sin(x)</m> across <m>y=x</m> yields <m>y=\arcsin(x)</m></caption>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/ArcTrig-5"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/ArcTrig-5"></image></cell>
         </row>
         <row>
           <cell><m>g(x) = \sin(x)</m>,  <m>-\frac{\pi}{2} \leq x \leq  \frac{\pi}{2}</m></cell>
@@ -207,7 +207,7 @@
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/ArcTrig-6"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/ArcTrig-6"></image></cell>
         </row>
         <row>
           <cell><m>g^{-1}(x) = \arcsin(x)</m></cell>
@@ -524,7 +524,7 @@
       <caption>Reflecting <m>y=\tan(x)</m> across <m>y=x</m> yields <m>y=\arctan(x)</m></caption>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/ArcTrig-7"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/ArcTrig-7"></image></cell>
         </row>
         <row>
           <cell><m>f(x) = \tan(x)</m>,  <m>-\frac{\pi}{2} \lt  x \lt   \frac{\pi}{2}</m></cell>
@@ -533,7 +533,7 @@
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/ArcTrig-8"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/ArcTrig-8"></image></cell>
         </row>
         <row>
           <cell><m>f^{-1}(x) = \arctan(x)</m></cell>
@@ -679,7 +679,7 @@
       <caption>Reflecting <m>y=\cot(x)</m> across <m>y=x</m> yields <m>y=\operatorname{arccot}(x)</m></caption>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/ArcTrig-9"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/ArcTrig-9"></image></cell>
         </row>
         <row>
           <cell><m>g(x) = \cot(x)</m>,  <m>0 \lt  x \lt   \pi</m></cell>
@@ -688,7 +688,7 @@
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/ArcTrig-10"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/ArcTrig-10"></image></cell>
         </row>
         <row>
           <cell><m>gf^{-1}(x) = \operatorname{arccot}(x)</m></cell>
@@ -906,8 +906,8 @@
     <sidebyside>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/ArcTrig-11"/></cell>
-          <cell><img src="figures/IntroTrigGraphics/ArcTrig-12"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/ArcTrig-11"></image></cell>
+          <cell><image source="figures/IntroTrigGraphics/ArcTrig-12"></image></cell>
         </row>
         <row>
           <cell>The graph <m>y=\sec(x)</m></cell>
@@ -1090,7 +1090,7 @@
       <caption>The <q>Trigonometry Friendly</q> definition of <m>\operatorname{arcsec}(x)</m></caption>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/ArcTrig-13"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/ArcTrig-13"></image></cell>
         </row>
         <row>
           <cell><m>f(x) = \sec(x)</m> on  <m>\left[0, \frac{\pi}{2}\right) \cup \left( \frac{\pi}{2}, \pi\right]</m></cell>
@@ -1099,7 +1099,7 @@
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/ArcTrig-14"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/ArcTrig-14"></image></cell>
         </row>
         <row>
           <cell><m>f^{-1}(x)=\operatorname{arcsec}(x)</m></cell>
@@ -1111,7 +1111,7 @@
       <caption>The <q>Trigonometry Friendly</q> definition of <m>\operatorname{arccsc}(x)</m></caption>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/ArcTrig-15"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/ArcTrig-15"></image></cell>
         </row>
         <row>
           <cell><m>g(x) = \csc(x)</m> on  <m>\left[-\frac{\pi}{2}, 0\right) \cup \left(0,  \frac{\pi}{2}\right]</m></cell>
@@ -1120,7 +1120,7 @@
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/ArcTrig-16"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/ArcTrig-16"></image></cell>
         </row>
         <row>
           <cell><m>g^{-1}(x)=\operatorname{arccsc}(x)</m></cell>
@@ -1454,7 +1454,7 @@
       <caption>The <q>Calculus Friendly</q> definition of <m>\operatorname{arcsec}(x)</m></caption>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/ArcTrig-17"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/ArcTrig-17"></image></cell>
         </row>
         <row>
           <cell><m>f(x) = \sec(x)</m> on  <m>\left[0, \frac{\pi}{2}\right) \cup \left[ \pi, \frac{3\pi}{2}\right)</m></cell>
@@ -1463,7 +1463,7 @@
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/ArcTrig-18"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/ArcTrig-18"></image></cell>
         </row>
         <row>
           <cell><m>f^{-1}(x)=\operatorname{arcsec}(x)</m></cell>
@@ -1475,7 +1475,7 @@
       <caption>The ``Calculus Friendly definition of <m>\operatorname{arccsc}(x)</m></caption>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/ArcTrig-19"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/ArcTrig-19"></image></cell>
         </row>
         <row>
           <cell><m>g(x) = \csc(x)</m> on  <m>\left(0, \frac{\pi}{2}\right] \cup \left(\pi,  \frac{3\pi}{2}\right]</m></cell>
@@ -1484,7 +1484,7 @@
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/ArcTrig-20"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/ArcTrig-20"></image></cell>
         </row>
         <row>
           <cell><m>g^{-1}(x)=\operatorname{arccsc}(x)</m></cell>
@@ -1822,7 +1822,7 @@
                     to get <m>\alpha = \operatorname{arccot}(2) =\arctan\left(\frac{1}{2}\right)</m> radians.
                     Since <m>\theta = \pi - \alpha = \pi - \arctan\left(\frac{1}{2}\right) \approx 2.6779</m> radians,
                     we get <m>\operatorname{arccot}(-2) \approx 2.6779</m>. <figure xml:id="fig_arctrig11"> <caption>Evaluating
-                    <m>\operatorname{arccot}(-2)</m></caption> <img src="figures/IntroTrigGraphics/ArcTrig-21"/> </figure> Another way to attack the problem is to use <m>\arctan\left(-\frac{1}{2}\right)</m>.
+                    <m>\operatorname{arccot}(-2)</m></caption> <image source="figures/IntroTrigGraphics/ArcTrig-21"></image> </figure> Another way to attack the problem is to use <m>\arctan\left(-\frac{1}{2}\right)</m>.
                     By definition,
                     the real number <m>t = \arctan\left(-\frac{1}{2}\right)</m> satisfies
                     <m>\tan(t) = -\frac{1}{2}</m> with <m>-\frac{\pi}{2} \lt t \lt \frac{\pi}{2}</m>.
@@ -1835,7 +1835,7 @@
                     and we get <m>\theta = \pi + \beta = \pi + \arctan\left(-\frac{1}{2}\right) \approx 2.6779</m> radians.
                     Hence, as before,
                     <m>\operatorname{arccot}(-2) \approx 2.6779</m>. <figure xml:id="fig_arctrig12"> <caption>Evaluating
-                    <m>\operatorname{arccot}(-2)</m></caption> <img src="figures/IntroTrigGraphics/ArcTrig-22"/> </figure>
+                    <m>\operatorname{arccot}(-2)</m></caption> <image source="figures/IntroTrigGraphics/ArcTrig-22"></image> </figure>
                   </p>
                 </li>
 
@@ -1862,7 +1862,7 @@
                     to get <m>\alpha = \operatorname{arccsc}\left(\frac{3}{2}\right) = \arcsin\left(\frac{2}{3}\right)</m> radians.
                     Since <m>\theta = \pi + \alpha = \pi + \arcsin\left(\frac{2}{3}\right) \approx 3.8713</m> radians,
                     <m>\operatorname{arccsc}\left(-\frac{3}{2}\right) \approx 3.8713</m>. <figure xml:id="fig_arctrig13"> <caption>Evaluating
-                    <m>\operatorname{arccsc}\left(-\frac{3}{2}\right)</m></caption> <img src="figures/IntroTrigGraphics/ArcTrig-23"/> </figure>
+                    <m>\operatorname{arccsc}\left(-\frac{3}{2}\right)</m></caption> <image source="figures/IntroTrigGraphics/ArcTrig-23"></image> </figure>
                   </p>
                 </li>
               </ol></li>
@@ -1888,7 +1888,7 @@
                     <m>(0, 0)</m> and <m>\left(5, \frac{\pi}{2}\right)</m>.
                     Plotting these values tells us that the range of <m>f</m> is
                     <m>\left[-\frac{\pi}{2}, \frac{\pi}{2}\right]</m>. (It also confirms our domain!) The graph in <xref ref="fig_arctrig14">Figure</xref>
-                    confirms our results. <figure xml:id="fig_arctrig14"> <caption><m>y=f(x)=\dfrac{\pi}{2}-\arccos\left(\dfrac{x}{5}\right)</m></caption> <img src="figures/IntroTrigGraphics/ArcTrig1"/> </figure>
+                    confirms our results. <figure xml:id="fig_arctrig14"> <caption><m>y=f(x)=\dfrac{\pi}{2}-\arccos\left(\dfrac{x}{5}\right)</m></caption> <image source="figures/IntroTrigGraphics/ArcTrig1"></image> </figure>
                   </p>
                 </li>
 
@@ -1914,7 +1914,7 @@
                     <m>y = F(x) = \arctan(x)</m> by a horizontal compression by a factor of <m>4</m> and a vertical stretch by a factor of <m>3</m>.
                     It is the latter which affects the range,
                     producing a range of <m>\left(-\frac{3\pi}{2}, \frac{3\pi}{2} \right)</m>.
-                    We confirm our findings using GeoGebra in <xref ref="fig_arctrig15">Figure</xref>. <figure xml:id="fig_arctrig15"> <caption><m>y=f(x)=3\arctan(4x)</m></caption> <img src="figures/IntroTrigGraphics/ArcTrig2"/> </figure>
+                    We confirm our findings using GeoGebra in <xref ref="fig_arctrig15">Figure</xref>. <figure xml:id="fig_arctrig15"> <caption><m>y=f(x)=3\arctan(4x)</m></caption> <image source="figures/IntroTrigGraphics/ArcTrig2"></image> </figure>
                   </p>
                 </li>
 
@@ -1967,7 +1967,7 @@
 
                     <figure xml:id="fig_arctrig16">
                       <caption><m>y=g(x)=\operatorname{arccot}\left(\dfrac{\pi}{2}\right)+\pi</m></caption>
-                      <img src="figures/IntroTrigGraphics/ArcTrig3"/>
+                      <image source="figures/IntroTrigGraphics/ArcTrig3"></image>
                     </figure>
 
                     <aside>
@@ -2008,8 +2008,8 @@
         <sidebyside>
           <tabular>
             <row>
-              <cell><img src="figures/IntroTrigGraphics/ArcTrig05"/></cell>
-              <cell><img src="figures/IntroTrigGraphics/ArcTrig06"/></cell>
+              <cell><image source="figures/IntroTrigGraphics/ArcTrig05"></image></cell>
+              <cell><image source="figures/IntroTrigGraphics/ArcTrig06"></image></cell>
             </row>
             <row>
               <cell>Front View</cell>
@@ -2032,7 +2032,7 @@
 
         <figure xml:id="fig_arctrigappex">
           <caption>Angle of inclination <m>\theta</m> for <xref ref="roofpitchex">Example</xref></caption>
-          <img src="figures/IntroTrigGraphics/ArcTrig-24"/>
+          <image source="figures/IntroTrigGraphics/ArcTrig-24"></image>
         </figure>
       </solution>
     </example>
@@ -2122,7 +2122,7 @@
                 in Quadrant I and Quadrant II. If we let <m>\alpha</m> denote the acute solution to the equation,
                 then all the solutions to this equation in Quadrant I are coterminal with <m>\alpha</m>,
                 and <m>\alpha</m> serves as the reference angle for all of the solutions to this equation in Quadrant II. <table xml:id="fig_trigeqn1"> <caption>Solving
-                <m>\sin(\theta)=\frac{1}{3}</m></caption> <tabular> <row> <cell><img src="figures/IntroTrigGraphics/ArcTrig-25"/></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/IntroTrigGraphics/ArcTrig-26"/></cell> </row> </tabular> </table> Since
+                <m>\sin(\theta)=\frac{1}{3}</m></caption> <tabular> <row> <cell><image source="figures/IntroTrigGraphics/ArcTrig-25"></image></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/IntroTrigGraphics/ArcTrig-26"></image></cell> </row> </tabular> </table> Since
                 <m>\frac{1}{3}</m> isn't the sine of any of the
                 <q>common angles</q> discussed earlier,
                 we use the arcsine functions to express our answers.
@@ -2145,7 +2145,7 @@
                 We may visualize the solutions to
                 <m>\tan(t)=-2</m> as angles <m>\theta</m> with <m>\tan(\theta) = -2</m>.
                 Since tangent is negative only in Quadrants II and IV, we focus our efforts there. <table xml:id="fig_trigeqn2"> <caption>Solving
-                <m>\tan(t)=-2</m></caption> <tabular> <row> <cell><img src="figures/IntroTrigGraphics/ArcTrig-27"/></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/IntroTrigGraphics/ArcTrig-28"/></cell> </row> </tabular> </table> Since <m>-2</m> isn't the tangent of any of the <q>common angles</q>,
+                <m>\tan(t)=-2</m></caption> <tabular> <row> <cell><image source="figures/IntroTrigGraphics/ArcTrig-27"></image></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/IntroTrigGraphics/ArcTrig-28"></image></cell> </row> </tabular> </table> Since <m>-2</m> isn't the tangent of any of the <q>common angles</q>,
                 we need to use the arctangent function to express our answers.
                 The real number <m>t = \arctan(-2)</m> satisfies
                 <m>\tan(t)=-2</m> and <m>-\frac{\pi}{2} \lt t \lt 0</m>.
@@ -2194,7 +2194,7 @@
                 we record our final answer to
           <m>\sec(x) = -\frac{5}{3}</m> as <m>x = \arccos\left(-\frac{3}{5}\right) + 2\pi k</m> or
                 <m>x = -\arccos\left(-\frac{3}{5}\right) + 2\pi k</m> for integers <m>k</m>. <table xml:id="fig_trigeqn3"> <caption>Solving
-                <m>\sec(x)=-\frac{5}{3}</m></caption> <tabular> <row> <cell><img src="figures/IntroTrigGraphics/ArcTrig-29"/></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/IntroTrigGraphics/ArcTrig-30"/></cell> </row> </tabular> </table>
+                <m>\sec(x)=-\frac{5}{3}</m></caption> <tabular> <row> <cell><image source="figures/IntroTrigGraphics/ArcTrig-29"></image></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/IntroTrigGraphics/ArcTrig-30"></image></cell> </row> </tabular> </table>
               </p>
             </li>
           </ol>
@@ -5171,7 +5171,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/ArcTrig-31"/>
+          <image source="figures/IntroTrigGraphics/ArcTrig-31"></image>
 
           <ol>
             <li>

--- a/ptx/CartesianPlane.ptx
+++ b/ptx/CartesianPlane.ptx
@@ -19,7 +19,7 @@
       </p>
     </aside>
     <p>
-      <img src="figures/RelationsandFunctionsGraphics/CartesianPlane-21"/>
+      <image source="figures/RelationsandFunctionsGraphics/CartesianPlane-21"></image>
     </p>
 
     <p>
@@ -85,8 +85,8 @@
     <sidebyside>
       <tabular>
         <row>
-          <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-22"/></cell>
-          <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-23"/></cell>
+          <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-22"></image></cell>
+          <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-23"></image></cell>
         </row>
       </tabular>
     </sidebyside>
@@ -161,7 +161,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/CartesianPlane-24"/>
+          <image source="figures/RelationsandFunctionsGraphics/CartesianPlane-24"></image>
         </p>
       </solution>
     </example>
@@ -176,7 +176,7 @@
 
     <figure xml:id="quadrant">
       <caption>The four quadrants of the Cartesian plane</caption>
-      <img src="figures/RelationsandFunctionsGraphics/CartesianPlane-25"/>
+      <image source="figures/RelationsandFunctionsGraphics/CartesianPlane-25"></image>
     </figure>
 
     <p>
@@ -244,7 +244,7 @@
 
     <figure xml:id="fig_plansymm">
       <caption>The three types of symmetry in the plane</caption>
-      <img src="figures/RelationsandFunctionsGraphics/CartesianPlane-26"/>
+      <image source="figures/RelationsandFunctionsGraphics/CartesianPlane-26"></image>
     </figure>
 
     <example xml:id="ex_planesymm">
@@ -311,7 +311,7 @@
 
         <figure xml:id="fig_pointsymm">
           <caption>The point <m>P(-2,3)</m> and its three reflections</caption>
-          <img src="figures/RelationsandFunctionsGraphics/CartesianPlane-27"/>
+          <image source="figures/RelationsandFunctionsGraphics/CartesianPlane-27"></image>
         </figure>
       </solution>
     </example>
@@ -381,13 +381,13 @@
       <caption>Distance between <m>P</m> and <m>Q</m></caption>
       <tabular>
         <row>
-          <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-28"/></cell>
+          <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-28"></image></cell>
         </row>
         <row>
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-29"/></cell>
+          <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-29"></image></cell>
         </row>
       </tabular>
     </table>
@@ -492,7 +492,7 @@
 
     <figure xml:id="fig_pointdist">
       <caption>Diagram for <xref ref="ex_pointwithdist">Example</xref></caption>
-      <img src="figures/RelationsandFunctionsGraphics/CartesianPlane-30"/>
+      <image source="figures/RelationsandFunctionsGraphics/CartesianPlane-30"></image>
     </figure>
 
     <p>
@@ -506,7 +506,7 @@
 
     <figure xml:id="fig_midptseg">
       <caption>The midpoint of a line segment</caption>
-      <img src="figures/RelationsandFunctionsGraphics/CartesianPlane-31"/>
+      <image source="figures/RelationsandFunctionsGraphics/CartesianPlane-31"></image>
     </figure>
 
     <p>
@@ -597,7 +597,7 @@
           Plot and label the points <m>\;A(-3, -7)</m>,
           <m>\;B(1.3, -2)</m>, <m>\;C(\pi, \sqrt{10})</m>,
           <m>\;D(0, 8)</m>, <m>\;E(-5.5, 0)</m>, <m>\;F(-8, 4)</m>,
-          <m>\;G(9.2, -7.8)</m> and <m>H(7, 5)</m> in the Cartesian Coordinate Plane given below. <img src="figures/RelationsandFunctionsGraphics/CartesianPlane-35"/>
+          <m>\;G(9.2, -7.8)</m> and <m>H(7, 5)</m> in the Cartesian Coordinate Plane given below. <image source="figures/RelationsandFunctionsGraphics/CartesianPlane-35"></image>
         </p>
       </statement>
       <answer>
@@ -609,7 +609,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/CartesianPlane-46"/>
+          <image source="figures/RelationsandFunctionsGraphics/CartesianPlane-46"></image>
         </p>
       </answer>
     </exercise>

--- a/ptx/CircularFunctions.ptx
+++ b/ptx/CircularFunctions.ptx
@@ -111,7 +111,7 @@
 
     <figure xml:id="fig_cirfun1">
       <caption>Explaining the tangent and secant functions</caption>
-      <img src="figures/IntroTrigGraphics/CircularFunctions-1"/>
+      <image source="figures/IntroTrigGraphics/CircularFunctions-1"></image>
     </figure>
 
     <p>
@@ -457,7 +457,7 @@
           <xref ref="cosineiszero">number</xref>
                 in <xref ref="TheUnitCircle">Section</xref>
                 for another example of this kind of simplification of the solution.) <table xml:id="fig_cirfun2"> <caption>Solving
-                <m>\tan(\theta)=\sqrt{3}</m></caption> <tabular> <row> <cell><img src="figures/IntroTrigGraphics/CircularFunctions-2"/></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/IntroTrigGraphics/CircularFunctions-3"/></cell> </row> </tabular> </table>
+                <m>\tan(\theta)=\sqrt{3}</m></caption> <tabular> <row> <cell><image source="figures/IntroTrigGraphics/CircularFunctions-2"></image></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/IntroTrigGraphics/CircularFunctions-3"></image></cell> </row> </tabular> </table>
               </p>
             </li>
 
@@ -478,7 +478,7 @@
                 Can these lists be combined?
                 Indeed they can - one such way to capture all the solutions is:
                 <m>\theta = \frac{3\pi}{4} + \pi k</m> for integers <m>k</m>. <table xml:id="fig_cirfun3"> <caption>Solving
-                <m>\cot(\theta)=-1</m></caption> <tabular> <row> <cell><img src="figures/IntroTrigGraphics/CircularFunctions-4"/></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/IntroTrigGraphics/CircularFunctions-5"/></cell> </row> </tabular> </table>
+                <m>\cot(\theta)=-1</m></caption> <tabular> <row> <cell><image source="figures/IntroTrigGraphics/CircularFunctions-4"></image></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/IntroTrigGraphics/CircularFunctions-5"></image></cell> </row> </tabular> </table>
               </p>
             </li>
           </ol>
@@ -609,11 +609,11 @@
 
             <li>
               <p>
-                <m>\tan(\theta) = \sin(\theta) \sec(\theta)</m> \setcounter{HW}{\value{enumi}}
+                <m>\tan(\theta) = \sin(\theta) \sec(\theta)</m>
               </p>
             </li>
 
-            \setcounter{enumi}{\value{HW}}
+            
 
             <li>
               <p>
@@ -623,11 +623,11 @@
 
             <li>
               <p>
-                <m>\dfrac{\sec(\theta)}{1 - \tan(\theta)} = \dfrac{1}{\cos(\theta) - \sin(\theta)}</m> \setcounter{HW}{\value{enumi}}
+                <m>\dfrac{\sec(\theta)}{1 - \tan(\theta)} = \dfrac{1}{\cos(\theta) - \sin(\theta)}</m>
               </p>
             </li>
 
-            \setcounter{enumi}{\value{HW}}
+            
 
             <li>
               <p>
@@ -1008,7 +1008,7 @@
 
     <figure xml:id="fig_cirfun4">
       <caption>A right-angled triangle</caption>
-      <img src="figures/IntroTrigGraphics/CircularFunctions-6"/>
+      <image source="figures/IntroTrigGraphics/CircularFunctions-6"></image>
     </figure>
 
     <theorem xml:id="circularfunctionstriangle">
@@ -1041,7 +1041,7 @@
 
     <figure xml:id="fig_cirfun5">
       <caption>The angle of inclination from the base line to the object is <m>\theta</m></caption>
-      <img src="figures/IntroTrigGraphics/CircularFunctions-7"/>
+      <image source="figures/IntroTrigGraphics/CircularFunctions-7"></image>
     </figure>
   </subsection>
 
@@ -1081,7 +1081,7 @@
                 gives <m>\tan\left(60^{\circ}\right) = \frac{h}{30}</m>.
                 From this we get <m>h = 30 \tan\left(60^{\circ}\right) = 30 \sqrt{3} \approx 51.96</m>.
                 Hence,
-          the Clocktower is approximately <m>52</m> feet tall. <figure xml:id="fig_cirfun6"> <caption>Finding the height of the Clocktower</caption> <img src="figures/IntroTrigGraphics/CircularFunctions-8"/> </figure>
+          the Clocktower is approximately <m>52</m> feet tall. <figure xml:id="fig_cirfun6"> <caption>Finding the height of the Clocktower</caption> <image source="figures/IntroTrigGraphics/CircularFunctions-8"></image> </figure>
               </p>
             </li>
 
@@ -1093,7 +1093,7 @@
 
                 <figure xml:id="fig_cirfun7">
                   <caption>Finding the height of a California Redwood</caption>
-                  <img src="figures/IntroTrigGraphics/CircularFunctions-9"/>
+                  <image source="figures/IntroTrigGraphics/CircularFunctions-9"></image>
                 </figure>
 
                 Using <xref ref="circularfunctionstriangle">Theorem</xref>,
@@ -1155,7 +1155,7 @@
     </p>
 
     <p>
-      <img src="figures/IntroTrigGraphics/CircularFunctions-10"/>
+      <image source="figures/IntroTrigGraphics/CircularFunctions-10"></image>
     </p>
 
     <p>
@@ -1947,7 +1947,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/CircularFunctions-11"/>
+          <image source="figures/IntroTrigGraphics/CircularFunctions-11"></image>
         </p>
       </statement>
       <answer>
@@ -1964,7 +1964,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/CircularFunctions-12"/>
+          <image source="figures/IntroTrigGraphics/CircularFunctions-12"></image>
         </p>
       </statement>
       <answer>
@@ -1981,7 +1981,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/CircularFunctions-13"/>
+          <image source="figures/IntroTrigGraphics/CircularFunctions-13"></image>
         </p>
       </statement>
       <answer>
@@ -1999,7 +1999,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/CircularFunctions-14"/>
+          <image source="figures/IntroTrigGraphics/CircularFunctions-14"></image>
         </p>
       </statement>
       <answer>
@@ -2137,7 +2137,7 @@
               <idx><h>angle</h><h>of depression</h></idx> the angle of depression (also known as <idx><h>angle</h><h>of declination</h></idx>
           the angle of declination).
           The angle of depression of an object refers to the angle whose initial side is a horizontal line above the object and whose terminal side is the line-of-sight to the object below the horizontal.
-          This is represented schematically below. <img src="figures/IntroTrigGraphics/CircularFunctions-15"/>
+          This is represented schematically below. <image source="figures/IntroTrigGraphics/CircularFunctions-15"></image>
         </p>
 
         <p>
@@ -2651,7 +2651,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/CircularFunctions-16"/>
+          <image source="figures/IntroTrigGraphics/CircularFunctions-16"></image>
 
           <ol>
             <li>

--- a/ptx/CmpNums.ptx
+++ b/ptx/CmpNums.ptx
@@ -158,11 +158,11 @@
 
             <li>
               <p>
-                <m>\dfrac{1-2i}{3-4i}</m> \setcounter{HW}{\value{enumi}}
+                <m>\dfrac{1-2i}{3-4i}</m>
               </p>
             </li>
 
-            \setcounter{enumi}{\value{HW}}
+            
 
             <li>
               <p>
@@ -178,7 +178,7 @@
 
             <li>
               <p>
-                <m>(x-[1+2i])(x-[1-2i])</m> \setcounter{HW}{\value{enumi}}
+                <m>(x-[1+2i])(x-[1-2i])</m>
               </p>
             </li>
           </ol>

--- a/ptx/ExpEquations.ptx
+++ b/ptx/ExpEquations.ptx
@@ -150,7 +150,7 @@
                 To check graphically, we set <m>f(x) = 2^{3x}</m> and
                 <m>g(x) = 16^{1-x}</m> and see that they intersect at <m>x=\frac{4}{7} \approx 0.5714</m>:
                 see <xref ref="fig_expeqn1">Figure</xref>. <figure xml:id="fig_expeqn1"> <caption>\color{red} <m>y=f(x)=2^{3x}</m> and {\color{blue}
-                <m>y=g(x)=16^{1-x}</m>}</caption> <img src="figures/ExpLogsGraphics/ExpLogs05"/> </figure>
+                <m>y=g(x)=16^{1-x}</m>}</caption> <image source="figures/ExpLogsGraphics/ExpLogs05"></image> </figure>
               </p>
             </li>
 
@@ -165,7 +165,7 @@
                 Using GeoGebra, we graph <m>f(x) = 2000</m> and
                 <m>g(x) = 1000 \cdot 3^{-0.1 x}</m> and find that they intersect at <m>x = -\frac{10\ln(2)}{\ln(3)} \approx -6.3093</m>:
                 see <xref ref="fig_expeqn2">Figure</xref>. <figure xml:id="fig_expeqn2"> <caption>\color{red} <m>y=f(x)=2000</m> and {\color{blue}
-                <m>y=g(x)=1000\cdot e^{-0.1x}</m>}</caption> <img src="figures/ExpLogsGraphics/ExpLogs06"/> </figure>
+                <m>y=g(x)=1000\cdot e^{-0.1x}</m>}</caption> <image source="figures/ExpLogsGraphics/ExpLogs06"></image> </figure>
               </p>
             </li>
 
@@ -201,7 +201,7 @@
                 <figure xml:id="fig_expeqn3">
                   <caption>\color{red} <m>y=f(x)=9\cdot 3^x</m> and
                   {\color{blue} <m>y=g(x)=7^{2x}</m>}</caption>
-                  <img src="figures/ExpLogsGraphics/ExpLogs07"/>
+                  <image source="figures/ExpLogsGraphics/ExpLogs07"></image>
                 </figure>
 
               </p>
@@ -227,7 +227,7 @@
                 <m>t = \ln(3)</m>. (Can you explain why?) GeoGebra confirms the graphs of <m>f(x) = 75</m> and
                 <m>g(x) = \frac{100}{1 + 3e^{-2x}}</m> intersect at <m>x = \ln(3) \approx 1.099</m>:
                 see <xref ref="fig_expeqn4">Figure</xref>. <figure xml:id="fig_expeqn4"> <caption>\color{red} <m>y=f(x)=75</m> and {\color{blue}
-                <m>y=g(x)=\frac{100}{1+3e^{-2x}}</m>}</caption> <img src="figures/ExpLogsGraphics/ExpLogs08"/> </figure>
+                <m>y=g(x)=\frac{100}{1+3e^{-2x}}</m>}</caption> <image source="figures/ExpLogsGraphics/ExpLogs08"></image> </figure>
               </p>
             </li>
 
@@ -255,7 +255,7 @@
                 Using GeoGebra, we see the graphs of <m>f(x) = 25^{x}</m> and
                 <m>g(x) = 5^{x} + 6</m> intersect at <m>x=\frac{\ln(3)}{\ln(5)} \approx 0.6826</m>:
                 see <xref ref="fig_expeqn5">Figure</xref>. <figure xml:id="fig_expeqn5"> <caption>\color{red} <m>y=f(x)=25^x</m> and {\color{blue}
-                <m>y=g(x)=5^x+6</m>}</caption> <img src="figures/ExpLogsGraphics/ExpLogs09"/> </figure>
+                <m>y=g(x)=5^x+6</m>}</caption> <image source="figures/ExpLogsGraphics/ExpLogs09"></image> </figure>
               </p>
             </li>
 
@@ -284,7 +284,7 @@
                 we see in <xref ref="fig_expeqn6">Figure</xref>
                 that the graphs intersect at
                 <m>x = \ln\left(5 + \sqrt{26}\right) \approx 2.312</m>. <figure xml:id="fig_expeqn6"> <caption>\color{red} <m>y=f(x)=\dfrac{e^x-e^{-x}}{2}</m> and {\color{blue}
-                <m>y=g(x)=5</m>}</caption> <img src="figures/ExpLogsGraphics/ExpLogs10"/> </figure>
+                <m>y=g(x)=5</m>}</caption> <image source="figures/ExpLogsGraphics/ExpLogs10"></image> </figure>
               </p>
             </li>
           </ol>
@@ -374,8 +374,8 @@
                 which corresponds to where the graph of <m>y=r(x) = 2^{x^2-3x} - 16</m>,
                 is on or above the <m>x</m>-axis:
                 see <xref ref="fig_expineq1">Figure</xref>. <table xml:id="fig_expineq1"> <caption>Solving
-                <m>2^{x^2-3x}-16\geq 0</m></caption> <tabular> <row> <cell><img src="figures/ExpLogsGraphics/ExpEquations-1"/></cell> </row> <row> <cell>Sign diagram for
-                <m>r(x)=2^{x^2-3x}-16</m></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/ExpLogsGraphics/ExpLogs11"/></cell> </row> <row> <cell><m>y=r(x)=2^{x^2-3x}-16</m></cell> </row> </tabular> </table>
+                <m>2^{x^2-3x}-16\geq 0</m></caption> <tabular> <row> <cell><image source="figures/ExpLogsGraphics/ExpEquations-1"></image></cell> </row> <row> <cell>Sign diagram for
+                <m>r(x)=2^{x^2-3x}-16</m></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/ExpLogsGraphics/ExpLogs11"></image></cell> </row> <row> <cell><m>y=r(x)=2^{x^2-3x}-16</m></cell> </row> </tabular> </table>
               </p>
             </li>
 
@@ -425,7 +425,7 @@
                 <sidebyside>
                   <figure>
                     <caption>Sign diagram for <m>r(x)=\dfrac{12-2e^x}{e^x-4}</m></caption>
-                    <img src="figures/ExpLogsGraphics/ExpEquations-2"/>
+                    <image source="figures/ExpLogsGraphics/ExpEquations-2"></image>
                   </figure>
 
                   <figure>
@@ -475,7 +475,7 @@
                 <sidebyside>
                   <figure>
                     <caption>Sign diagram for <m>r(x)=xe^{2x}-4x</m></caption>
-                    <img src="figures/ExpLogsGraphics/ExpEquations-3"/>
+                    <image source="figures/ExpLogsGraphics/ExpEquations-3"></image>
                   </figure>
 
                   <figure>
@@ -530,7 +530,7 @@
           <caption>Solving <m>T(t)=100</m> in <xref ref="ex_newtoncool2">Example</xref></caption>
           <tabular>
             <row>
-              <cell><img src="figures/ExpLogsGraphics/ExpEquations-4"/></cell>
+              <cell><image source="figures/ExpLogsGraphics/ExpEquations-4"></image></cell>
             </row>
             <row>
               <cell>Sign diagram for <m>r(t)=90e^{-0.1t}-30</m></cell>
@@ -539,7 +539,7 @@
               <cell></cell>
             </row>
             <row>
-              <cell><img src="figures/ExpLogsGraphics/ExpEquations-5"/></cell>
+              <cell><image source="figures/ExpLogsGraphics/ExpEquations-5"></image></cell>
             </row>
             <row>
               <cell><m>y=T(t)</m> and <m>y=100</m></cell>
@@ -603,7 +603,7 @@
         <figure xml:id="fig_expinverse">
           <caption>\color{red} <m>y=f(x)=\frac{5e^x}{e^x+1}</m>
           {\color{blue} <m>y=g(x)=\ln\left(\frac{x}{5-x}\right)</m>}</caption>
-          <img src="figures/ExpLogsGraphics/ExpLogs14"/>
+          <image source="figures/ExpLogsGraphics/ExpLogs14"></image>
         </figure>
       </solution>
     </example>

--- a/ptx/ExpLogApplications.ptx
+++ b/ptx/ExpLogApplications.ptx
@@ -737,8 +737,8 @@
                 confirming our answer to part 2, and the graph intersects the line <m>y=42</m> at
                 <m>x = \ln(2799) \approx 7.937</m> in <xref ref="fig_expapp2">Figure</xref>,
                 which confirms our answer to part 3. <figure xml:id="fig_expapp1"> <caption>\color{red}
-          <m>y=\dfrac{84}{1+2799e^{-x}}</m> and {\color{blue} <m>y=84</m>}</caption> <img src="figures/ExpLogsGraphics/ExpLogs26"/> </figure> <figure xml:id="fig_expapp2"> <caption>\color{red}
-                <m>y=\dfrac{84}{1+2799e^{-x}}</m> and {\color{blue} <m>y=42</m>}</caption> <img src="figures/ExpLogsGraphics/ExpLogs27"/> </figure>
+          <m>y=\dfrac{84}{1+2799e^{-x}}</m> and {\color{blue} <m>y=84</m>}</caption> <image source="figures/ExpLogsGraphics/ExpLogs26"></image> </figure> <figure xml:id="fig_expapp2"> <caption>\color{red}
+                <m>y=\dfrac{84}{1+2799e^{-x}}</m> and {\color{blue} <m>y=42</m>}</caption> <image source="figures/ExpLogsGraphics/ExpLogs27"></image> </figure>
               </p>
             </li>
           </ol>
@@ -771,13 +771,13 @@
     <figure xml:id="fig_expapp3">
       <caption><m>y=\dfrac{84}{1+2799e^{-x}}</m>
       for <m>0\leq x\leq 8</m></caption>
-      <img src="figures/ExpLogsGraphics/ExpLogs28"/>
+      <image source="figures/ExpLogsGraphics/ExpLogs28"></image>
     </figure>
 
     <figure xml:id="fig_expapp4">
       <caption><m>y=\dfrac{84}{1+2799e^{-x}}</m>
       for <m>8\leq x\leq 16</m></caption>
-      <img src="figures/ExpLogsGraphics/ExpLogs29"/>
+      <image source="figures/ExpLogsGraphics/ExpLogs29"></image>
     </figure>
   </subsection>
 
@@ -2068,7 +2068,7 @@
         </p>
 
         <p>
-          <img src="figures/ExpLogsGraphics/PURSUIT03.jpg"/>
+          <image source="figures/ExpLogsGraphics/PURSUIT03.jpg"></image>
         </p>
 
         <p>

--- a/ptx/FunctionArithmetic.ptx
+++ b/ptx/FunctionArithmetic.ptx
@@ -108,11 +108,11 @@
 
             <li>
               <p>
-                Find <m>(fg)(2)</m> \setcounter{HW}{\value{enumi}}
+                Find <m>(fg)(2)</m>
               </p>
             </li>
 
-            \setcounter{enumi}{\value{HW}}
+            
 
             <li>
               <p>

--- a/ptx/FunctionComposition.ptx
+++ b/ptx/FunctionComposition.ptx
@@ -89,7 +89,7 @@
 
     <figure xml:id="fig_funccomp1">
       <caption>Composition of functions</caption>
-      <img src="figures/FurtherGraphics/FunctionComposition-1"/>
+      <image source="figures/FurtherGraphics/FunctionComposition-1"></image>
     </figure>
 
     <p>
@@ -237,7 +237,7 @@
 
         <figure xml:id="fig_funcompsd1">
           <caption>The sign diagram of <m>r(x)=x^2-4x+3</m></caption>
-          <img src="figures/FurtherGraphics/FunctionComposition-2"/>
+          <image source="figures/FurtherGraphics/FunctionComposition-2"></image>
         </figure>
 
         <p>
@@ -361,7 +361,7 @@
         <figure xml:id="fig_funcompsd2">
           <caption>The sign diagram of 
           <m>r(x)=\dfrac{5x+3}{x+1}</m></caption>
-          <img src="figures/FurtherGraphics/FunctionComposition-3"/>
+          <image source="figures/FurtherGraphics/FunctionComposition-3"></image>
         </figure>
 
         <p>
@@ -2348,8 +2348,8 @@
     </p>
     <tabular>
       <row>
-        <cell><img src="figures/FurtherGraphics/FunctionComposition-4"/></cell>
-        <cell><img src="figures/FurtherGraphics/FunctionComposition-5"/></cell>
+        <cell><image source="figures/FurtherGraphics/FunctionComposition-4"></image></cell>
+        <cell><image source="figures/FurtherGraphics/FunctionComposition-5"></image></cell>
       </row>
     </tabular>
     <exercise>

--- a/ptx/FunctionNotation.ptx
+++ b/ptx/FunctionNotation.ptx
@@ -29,7 +29,7 @@
 
     <figure xml:id="fig_functpic">
       <caption>Graphical depiction of a function</caption>
-      <img src="figures/RelationsandFunctionsGraphics/FunctionNotation-1"/>
+      <image source="figures/RelationsandFunctionsGraphics/FunctionNotation-1"></image>
     </figure>
 
     <p>

--- a/ptx/GraphsofFunctions.ptx
+++ b/ptx/GraphsofFunctions.ptx
@@ -168,7 +168,7 @@
           <cell></cell>
         </row>
       </tabular>
-      <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-1"/>
+      <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-1"></image>
     </table>
 
     <p>
@@ -283,7 +283,7 @@
           <cell></cell>
         </row>
       </tabular>
-      <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-2"/>
+      <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-2"></image>
     </table>
 
     <p>
@@ -428,7 +428,7 @@
 
           <li>
             <p>
-              <m>p(x) = \begin{cases}x+3 \amp \text{ if } x \lt 0 \\ -x+3, \amp \text{ if } x \geq 0 \end{cases} </m>. \setcounter{HW}{\value{enumi}}
+              <m>p(x) = \begin{cases}x+3 \amp \text{ if } x \lt 0 \\ -x+3, \amp \text{ if } x \geq 0 \end{cases} </m>.
             </p>
           </li>
         </ol>
@@ -451,7 +451,7 @@
 
                 <figure xml:id="fig_evenodd1">
                   <caption>The graph of <m>f(x)</m> in <xref ref="ex_evenodd">Example</xref></caption>
-                  <img src="figures/RelationsandFunctionsGraphics/GoF-1"/>
+                  <image source="figures/RelationsandFunctionsGraphics/GoF-1"></image>
                 </figure>
 
                 This suggests that the graph of <m>f</m> is symmetric about the <m>y</m>-axis,
@@ -491,7 +491,7 @@
 
                 <figure xml:id="fig_evenodd2">
                   <caption>The graph of <m>g(x)</m> in <xref ref="ex_evenodd">Example</xref></caption>
-                  <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions_02"/>
+                  <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions_02"></image>
                 </figure>
 
               </p>
@@ -512,7 +512,7 @@
 
                 <figure xml:id="fig_evenodd3">
                   <caption>The graph of <m>h(x)</m> in <xref ref="ex_evenodd">Example</xref></caption>
-                  <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions_03"/>
+                  <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions_03"></image>
                 </figure>
 
                 In <xref ref="fig_evenodd3">Figure</xref>,
@@ -556,7 +556,7 @@
 
                 <figure xml:id="fig_evenodd4">
                   <caption>The graph of <m>i(x)</m> in <xref ref="ex_evenodd">Example</xref></caption>
-                  <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions_04"/>
+                  <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions_04"></image>
                 </figure>
 
               </p>
@@ -587,7 +587,7 @@
 
                 <figure xml:id="fig_evenodd5">
                   <caption>The graph of <m>j(x)</m> in <xref ref="ex_evenodd">Example</xref></caption>
-                  <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions_05"/>
+                  <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions_05"></image>
                 </figure>
 
                 Notice in <xref ref="fig_evenodd5">Figure</xref>
@@ -620,7 +620,7 @@
                 Hence, in all cases,
           <m>p(-x) = p(x)</m>, so <m>p</m> is even.
                 Since <m>p(0) = 3</m> but <m>p(-0) = p(0) = 3 \neq -3</m>,
-                we also have <m>p</m> is not odd. <figure xml:id="fig_evenodd6"> <caption>The graph of <m>p(x)</m> in <xref ref="ex_evenodd">Example</xref></caption> <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions_06"/> </figure> In <xref ref="fig_evenodd6">Figure</xref>,
+                we also have <m>p</m> is not odd. <figure xml:id="fig_evenodd6"> <caption>The graph of <m>p(x)</m> in <xref ref="ex_evenodd">Example</xref></caption> <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions_06"></image> </figure> In <xref ref="fig_evenodd6">Figure</xref>,
                 we see that the graph appears to be symmetric about the <m>y</m>-axis.
               </p>
             </li>
@@ -707,7 +707,7 @@
     </aside>
     <figure xml:id="fig_genbehav">
       <caption>The graph <m>y=f(x)</m></caption>
-      <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-3"/>
+      <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-3"></image>
     </figure>
 
     <p>
@@ -905,7 +905,7 @@
 
         <figure xml:id="fig_tamegraph">
           <caption>The graph for <xref ref="tame">Example</xref></caption>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-4"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-4"></image>
         </figure>
 
         <ol>
@@ -1088,7 +1088,7 @@
                 we see that the curve has two points with a <m>y</m> value of <m>1</m>,
                 as seen in the graph below.
                 That means there are two solutions to <m>f(x) = 1</m>:
-                see <xref ref="fig_tamey1">Figure</xref>. <figure xml:id="fig_tamey1"> <caption>Solving <m>f(x)=1</m> in <xref ref="tame">Example</xref>.9</caption> <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-5"/> </figure>
+                see <xref ref="fig_tamey1">Figure</xref>. <figure xml:id="fig_tamey1"> <caption>Solving <m>f(x)=1</m> in <xref ref="tame">Example</xref>.9</caption> <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-5"></image> </figure>
               </p>
             </li>
 
@@ -1169,7 +1169,7 @@
 
     <figure xml:id="fig_maxmincomp1">
       <caption>The local maximum and minimum of <m>f(x) = \dfrac{15x}{x^2+3}</m> in <xref ref="ex_maxmincomp">Example</xref></caption>
-      <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions_07"/>
+      <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions_07"></image>
     </figure>
 
     <example xml:id="ex_maxmincomp">
@@ -1241,7 +1241,7 @@
 
         <figure xml:id="fig_distfunctex">
           <caption>Minimizing <m>d(x)</m> in <xref ref="distancefunctionex">Example</xref></caption>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions_08"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions_08"></image>
         </figure>
 
         <p>
@@ -1305,7 +1305,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-17"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-17"></image>
         </p>
       </answer>
     </exercise>
@@ -1337,7 +1337,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-18"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-18"></image>
         </p>
       </answer>
     </exercise>
@@ -1369,7 +1369,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-19"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-19"></image>
         </p>
       </answer>
     </exercise>
@@ -1401,7 +1401,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-20"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-20"></image>
         </p>
       </answer>
     </exercise>
@@ -1433,7 +1433,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-21"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-21"></image>
         </p>
       </answer>
     </exercise>
@@ -1465,7 +1465,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-22"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-22"></image>
         </p>
       </answer>
     </exercise>
@@ -1498,7 +1498,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-23"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-23"></image>
         </p>
       </answer>
     </exercise>
@@ -1530,7 +1530,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-24"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-24"></image>
         </p>
       </answer>
     </exercise>
@@ -1562,7 +1562,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-25"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-25"></image>
         </p>
       </answer>
     </exercise>
@@ -1594,7 +1594,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-26"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-26"></image>
         </p>
       </answer>
     </exercise>
@@ -1626,7 +1626,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-27"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-27"></image>
         </p>
       </answer>
     </exercise>
@@ -1658,7 +1658,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-28"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-28"></image>
         </p>
       </answer>
     </exercise>
@@ -1674,7 +1674,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-29"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-29"></image>
         </p>
       </answer>
     </exercise>
@@ -1686,7 +1686,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-30"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-30"></image>
         </p>
       </answer>
     </exercise>
@@ -1698,7 +1698,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-31"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-31"></image>
         </p>
       </answer>
     </exercise>
@@ -1710,7 +1710,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-32"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-32"></image>
         </p>
       </answer>
     </exercise>
@@ -1722,7 +1722,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-33"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-33"></image>
         </p>
       </answer>
     </exercise>
@@ -1734,7 +1734,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-34"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-34"></image>
         </p>
       </answer>
     </exercise>
@@ -1746,7 +1746,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-35"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-35"></image>
         </p>
       </answer>
     </exercise>
@@ -1758,7 +1758,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-36"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-36"></image>
         </p>
       </answer>
     </exercise>
@@ -2025,7 +2025,7 @@
     </p>
 
     <p>
-      <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-6"/>
+      <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-6"></image>
     </p>
     <exercise>
       <statement>
@@ -2225,7 +2225,7 @@
     </p>
 
     <p>
-      <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-7"/>
+      <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-7"></image>
     </p>
     <exercise>
       <statement>
@@ -2564,8 +2564,8 @@
     </p>
     <tabular>
       <row>
-        <cell><img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-8"/></cell>
-        <cell><img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-9"/></cell>
+        <cell><image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-8"></image></cell>
+        <cell><image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-9"></image></cell>
       </row>
       <row>
         <cell><m>y=f(x)</m></cell>
@@ -2676,7 +2676,7 @@
     </p>
 
     <p>
-      <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-10"/>
+      <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-10"></image>
     </p>
     <exercise>
       <statement>
@@ -2757,7 +2757,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-37"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-37"></image>
         </p>
 
         <p>
@@ -2839,7 +2839,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-11"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-11"></image>
 
           <ol>
             <li>
@@ -2882,7 +2882,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-12"/>
+          <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-12"></image>
         </p>
       </statement>
     </exercise>
@@ -2902,25 +2902,25 @@
           <ol>
             <li>
               <p>
-                <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-13"/>
+                <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-13"></image>
               </p>
             </li>
 
             <li>
               <p>
-                <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-14"/>
+                <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-14"></image>
               </p>
             </li>
 
             <li>
               <p>
-                <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-15"/>
+                <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-15"></image>
               </p>
             </li>
 
             <li>
               <p>
-                <img src="figures/RelationsandFunctionsGraphics/GraphsofFunctions-16"/>
+                <image source="figures/RelationsandFunctionsGraphics/GraphsofFunctions-16"></image>
               </p>
             </li>
           </ol>

--- a/ptx/GraphsofPolynomials.ptx
+++ b/ptx/GraphsofPolynomials.ptx
@@ -282,11 +282,11 @@
 
             <li>
               <p>
-                <m>g(x) = 12x +x^3</m> \setcounter{HW}{\value{enumi}}
+                <m>g(x) = 12x +x^3</m>
               </p>
             </li>
 
-            \setcounter{enumi}{\value{HW}}
+            
 
             <li>
               <p>
@@ -382,7 +382,7 @@
             <li>
               <p>
                 Use software or a graphing calculator to graph <m>y=V(x)</m> on the domain you found in part 1 and approximate the dimensions of the box with maximum volume to two decimal places.
-                What is the maximum volume? <table xml:id="fig_boxnotop"> <caption>Constructing the box in <xref ref="boxnotopex">Example</xref></caption> <tabular> <row> <cell><img src="figures/PolynomialsGraphics/GraphsofPolynomials-1"/></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/PolynomialsGraphics/GraphsofPolynomials-2"/></cell> </row> </tabular> </table>
+                What is the maximum volume? <table xml:id="fig_boxnotop"> <caption>Constructing the box in <xref ref="boxnotopex">Example</xref></caption> <tabular> <row> <cell><image source="figures/PolynomialsGraphics/GraphsofPolynomials-1"></image></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/PolynomialsGraphics/GraphsofPolynomials-2"></image></cell> </row> </tabular> </table>
               </p>
             </li>
           </ol>
@@ -454,7 +454,7 @@
       <caption>Optimizing the volume of the box in <xref ref="boxnotopex">Example</xref></caption>
       <tabular>
         <row>
-          <cell><img src="figures/PolynomialsGraphics/BoxNoTopV"/></cell>
+          <cell><image source="figures/PolynomialsGraphics/BoxNoTopV"></image></cell>
         </row>
         <row>
           <cell>The graph <m>y=V(x)</m></cell>
@@ -463,7 +463,7 @@
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/PolynomialsGraphics/BoxNoTopVmax"/></cell>
+          <cell><image source="figures/PolynomialsGraphics/BoxNoTopVmax"></image></cell>
         </row>
         <row>
           <cell>The graph <m>y=V(x)</m> with maximum shown</cell>
@@ -569,9 +569,9 @@
       </p>
       <tabular>
         <row>
-          <cell><img src="figures/PolynomialsGraphics/GraphsofPolynomials-6"/></cell>
+          <cell><image source="figures/PolynomialsGraphics/GraphsofPolynomials-6"></image></cell>
           <cell>\hspace{2cm}</cell>
-          <cell><img src="figures/PolynomialsGraphics/GraphsofPolynomials-7"/></cell>
+          <cell><image source="figures/PolynomialsGraphics/GraphsofPolynomials-7"></image></cell>
         </row>
         <row>
           <cell><m>a>0</m></cell>
@@ -600,7 +600,7 @@
     <sidebyside>
       <figure>
         <caption><m>y=x^2</m></caption>
-        <img src="figures/PolynomialsGraphics/GraphsofPolynomials-3"/>
+        <image source="figures/PolynomialsGraphics/GraphsofPolynomials-3"></image>
       </figure>
 
       <figure>
@@ -609,7 +609,7 @@
 
       <figure>
         <caption><m>y=x^6</m></caption>
-        <img src="figures/PolynomialsGraphics/GraphsofPolynomials-5"/>
+        <image source="figures/PolynomialsGraphics/GraphsofPolynomials-5"></image>
       </figure>
     </sidebyside>
     </figure>
@@ -619,7 +619,7 @@
     <sidebyside>
       <figure>
         <caption><m>y=x^3</m></caption>
-        <img src="figures/PolynomialsGraphics/GraphsofPolynomials-8"/>
+        <image source="figures/PolynomialsGraphics/GraphsofPolynomials-8"></image>
       </figure>
 
       <figure>
@@ -628,7 +628,7 @@
 
       <figure>
         <caption><m>y=x^7</m></caption>
-        <img src="figures/PolynomialsGraphics/GraphsofPolynomials-10"/>
+        <image source="figures/PolynomialsGraphics/GraphsofPolynomials-10"></image>
       </figure>
     </sidebyside>
     </figure>
@@ -669,9 +669,9 @@
       </p>
       <tabular>
         <row>
-          <cell><img src="figures/PolynomialsGraphics/GraphsofPolynomials-11"/></cell>
+          <cell><image source="figures/PolynomialsGraphics/GraphsofPolynomials-11"></image></cell>
           <cell>\hspace{2cm}</cell>
-          <cell><img src="figures/PolynomialsGraphics/GraphsofPolynomials-12"/></cell>
+          <cell><image source="figures/PolynomialsGraphics/GraphsofPolynomials-12"></image></cell>
         </row>
         <row>
           <cell><m>a>0</m></cell>
@@ -720,7 +720,7 @@
     </aside>
     <figure xml:id="cusppicture">
       <caption>Pathologies not found on graphs of polynomials</caption>
-      <img src="figures/PolynomialsGraphics/GraphsofPolynomials-13"/>
+      <image source="figures/PolynomialsGraphics/GraphsofPolynomials-13"></image>
     </figure>
 
     <p>
@@ -748,7 +748,7 @@
 
     <figure xml:id="fig_polygraphgen">
       <caption>The graph of a polynomial</caption>
-      <img src="figures/PolynomialsGraphics/GraphsofPolynomials-14"/>
+      <image source="figures/PolynomialsGraphics/GraphsofPolynomials-14"></image>
     </figure>
 
     <p>
@@ -860,12 +860,12 @@
 
         <figure xml:id="fig_polysign1">
           <caption>The sign diagram of <m>f</m> in <xref ref="polygraphex">Example</xref></caption>
-          <img src="figures/PolynomialsGraphics/GraphsofPolynomials-15"/>
+          <image source="figures/PolynomialsGraphics/GraphsofPolynomials-15"></image>
         </figure>
 
         <figure xml:id="fig_polygraph1">
           <caption>The graph <m>y=f(x)</m> for <xref ref="polygraphex">Example</xref></caption>
-          <img src="figures/PolynomialsGraphics/GraphsofPolynomials-16"/>
+          <image source="figures/PolynomialsGraphics/GraphsofPolynomials-16"></image>
         </figure>
       </solution>
     </example>
@@ -957,7 +957,7 @@
       <caption>Two views of the polynomials <m>f(x)</m> and <m>g(x)</m></caption>
       <tabular>
         <row>
-          <cell><img src="figures/PolynomialsGraphics/EndBehaviour_near"/></cell>
+          <cell><image source="figures/PolynomialsGraphics/EndBehaviour_near"></image></cell>
         </row>
         <row>
           <cell>A view close to the origin</cell>
@@ -966,7 +966,7 @@
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/PolynomialsGraphics/EndBehaviour_far"/></cell>
+          <cell><image source="figures/PolynomialsGraphics/EndBehaviour_far"></image></cell>
         </row>
         <row>
           <cell>A <q>zoomed out</q> view</cell>
@@ -1116,7 +1116,7 @@
 
         <figure xml:id="fig_polygraph2">
           <caption>The graph <m>y=f(x)</m> for <xref ref="ex_multiplicity">Example</xref></caption>
-          <img src="figures/PolynomialsGraphics/GraphsofPolynomials-19"/>
+          <image source="figures/PolynomialsGraphics/GraphsofPolynomials-19"></image>
         </figure>
       </solution>
     </example>
@@ -1514,7 +1514,7 @@
         </p>
 
         <p>
-          <img src="figures/PolynomialsGraphics/GraphsofPolynomials-21"/>
+          <image source="figures/PolynomialsGraphics/GraphsofPolynomials-21"></image>
         </p>
       </answer>
     </exercise>
@@ -1538,7 +1538,7 @@
         </p>
 
         <p>
-          <img src="figures/PolynomialsGraphics/GraphsofPolynomials-22"/>
+          <image source="figures/PolynomialsGraphics/GraphsofPolynomials-22"></image>
         </p>
       </answer>
     </exercise>
@@ -1562,7 +1562,7 @@
         </p>
 
         <p>
-          <img src="figures/PolynomialsGraphics/GraphsofPolynomials-23"/>
+          <image source="figures/PolynomialsGraphics/GraphsofPolynomials-23"></image>
         </p>
       </answer>
     </exercise>
@@ -1586,7 +1586,7 @@
         </p>
 
         <p>
-          <img src="figures/PolynomialsGraphics/GraphsofPolynomials-24"/>
+          <image source="figures/PolynomialsGraphics/GraphsofPolynomials-24"></image>
         </p>
       </answer>
     </exercise>
@@ -1610,7 +1610,7 @@
         </p>
 
         <p>
-          <img src="figures/PolynomialsGraphics/GraphsofPolynomials-25"/>
+          <image source="figures/PolynomialsGraphics/GraphsofPolynomials-25"></image>
         </p>
       </answer>
     </exercise>
@@ -1642,7 +1642,7 @@
         </p>
 
         <p>
-          <img src="figures/PolynomialsGraphics/GraphsofPolynomials-26"/>
+          <image source="figures/PolynomialsGraphics/GraphsofPolynomials-26"></image>
         </p>
       </answer>
     </exercise>
@@ -1666,7 +1666,7 @@
         </p>
 
         <p>
-          <img src="figures/PolynomialsGraphics/GraphsofPolynomials-27"/>
+          <image source="figures/PolynomialsGraphics/GraphsofPolynomials-27"></image>
         </p>
       </answer>
     </exercise>
@@ -1694,7 +1694,7 @@
         </p>
 
         <p>
-          <img src="figures/PolynomialsGraphics/GraphsofPolynomials-28"/>
+          <image source="figures/PolynomialsGraphics/GraphsofPolynomials-28"></image>
         </p>
       </answer>
     </exercise>
@@ -1714,7 +1714,7 @@
         </p>
 
         <p>
-          <img src="figures/PolynomialsGraphics/GraphsofPolynomials-29"/>
+          <image source="figures/PolynomialsGraphics/GraphsofPolynomials-29"></image>
         </p>
       </answer>
     </exercise>
@@ -1742,7 +1742,7 @@
         </p>
 
         <p>
-          <img src="figures/PolynomialsGraphics/GraphsofPolynomials-30"/>
+          <image source="figures/PolynomialsGraphics/GraphsofPolynomials-30"></image>
         </p>
       </answer>
     </exercise>
@@ -1773,7 +1773,7 @@
         </p>
 
         <p>
-          <img src="figures/PolynomialsGraphics/GraphsofPolynomials-31"/>
+          <image source="figures/PolynomialsGraphics/GraphsofPolynomials-31"></image>
         </p>
       </answer>
     </exercise>
@@ -1797,7 +1797,7 @@
         </p>
 
         <p>
-          <img src="figures/PolynomialsGraphics/GraphsofPolynomials-32"/>
+          <image source="figures/PolynomialsGraphics/GraphsofPolynomials-32"></image>
         </p>
       </answer>
     </exercise>
@@ -1821,7 +1821,7 @@
         </p>
 
         <p>
-          <img src="figures/PolynomialsGraphics/GraphsofPolynomials-33"/>
+          <image source="figures/PolynomialsGraphics/GraphsofPolynomials-33"></image>
         </p>
       </answer>
     </exercise>
@@ -1845,7 +1845,7 @@
         </p>
 
         <p>
-          <img src="figures/PolynomialsGraphics/GraphsofPolynomials-34"/>
+          <image source="figures/PolynomialsGraphics/GraphsofPolynomials-34"></image>
         </p>
       </answer>
     </exercise>
@@ -1869,7 +1869,7 @@
         </p>
 
         <p>
-          <img src="figures/PolynomialsGraphics/GraphsofPolynomials-35"/>
+          <image source="figures/PolynomialsGraphics/GraphsofPolynomials-35"></image>
         </p>
       </answer>
     </exercise>
@@ -1893,7 +1893,7 @@
         </p>
 
         <p>
-          <img src="figures/PolynomialsGraphics/GraphsofPolynomials-36"/>
+          <image source="figures/PolynomialsGraphics/GraphsofPolynomials-36"></image>
         </p>
       </answer>
     </exercise>
@@ -2064,7 +2064,7 @@
         </p>
 
         <p>
-          <img src="figures/PolynomialsGraphics/GraphsofPolynomials-20"/>
+          <image source="figures/PolynomialsGraphics/GraphsofPolynomials-20"></image>
         </p>
       </statement>
       <answer>

--- a/ptx/Identities.ptx
+++ b/ptx/Identities.ptx
@@ -88,13 +88,13 @@
       <caption>Establishing <xref ref="evenodd">Theorem</xref></caption>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/Identities-1"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/Identities-1"></image></cell>
         </row>
         <row>
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/Identities-2"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/Identities-2"></image></cell>
         </row>
       </tabular>
     </table>
@@ -168,13 +168,13 @@
       <caption>Establishing <xref ref="cosinesumdifference">Theorem</xref></caption>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/Identities-3"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/Identities-3"></image></cell>
         </row>
         <row>
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/Identities-4"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/Identities-4"></image></cell>
         </row>
       </tabular>
     </table>

--- a/ptx/Inequalities.ptx
+++ b/ptx/Inequalities.ptx
@@ -72,9 +72,9 @@
               <p>
                 To graph <m>y=f(x)</m>, we graph <m>y = 2x-1</m>,
                 which is a line with a <m>y</m>-intercept of <m>(0,-1)</m> and a slope of <m>2</m>.
-                The graph of <m>y=g(x)</m> is <m>y=5</m> which is a horizontal line through <m>(0,5)</m>. <figure xml:id="fig_linearineq"> <caption>Graphical interpretation of <xref ref="ex_motineq">Example</xref></caption> <sidebyside> <figure> <caption>Intersecting graphs <m>y=f(x)</m> and <m>y=g(x)</m></caption> <img src="figures/LinearQuadraticGraphics/Inequalities-1"/> </figure> <figure> <m>f(x)\lt g(x)</m> on
+                The graph of <m>y=g(x)</m> is <m>y=5</m> which is a horizontal line through <m>(0,5)</m>. <figure xml:id="fig_linearineq"> <caption>Graphical interpretation of <xref ref="ex_motineq">Example</xref></caption> <sidebyside> <figure> <caption>Intersecting graphs <m>y=f(x)</m> and <m>y=g(x)</m></caption> <image source="figures/LinearQuadraticGraphics/Inequalities-1"></image> </figure> <figure> <m>f(x)\lt g(x)</m> on
                 <m>(-\infty, 3)</m> </figure> <figure> <caption><m>f(x)>g(x)</m> on
-                <m>(3,\infty)</m></caption> <img src="figures/LinearQuadraticGraphics/Inequalities-3"/> </figure> </sidebyside> </figure> To see the connection between the graph and the Algebra,
+                <m>(3,\infty)</m></caption> <image source="figures/LinearQuadraticGraphics/Inequalities-3"></image> </figure> </sidebyside> </figure> To see the connection between the graph and the Algebra,
                 we recall the Fundamental Graphing Principle for Functions in <xref ref="GraphsofFunctions">Section</xref>:
                 the point <m>(a,b)</m> is on the graph of <m>f</m> if and only if <m>f(a)=b</m>.
                 In other words,
@@ -150,7 +150,7 @@
 
         <figure xml:id="fig_graphineq">
           <caption>The graphs <m>y=f(x)</m> and <m>y=g(x)</m> for <xref ref="ex_solvewithgraph">Example</xref></caption>
-          <img src="figures/LinearQuadraticGraphics/Inequalities-4"/>
+          <image source="figures/LinearQuadraticGraphics/Inequalities-4"></image>
         </figure>
 
         <ol>
@@ -207,8 +207,8 @@
                 on the interval <m>(-1,1)</m>.
                 Hence, our solution to
           <m>f(x) \geq g(x)</m> is <m>[-1,1]</m>. <figure xml:id="fig_graphineq1"> <caption>The solution to
-                <m>f(x)\lt g(x)</m></caption> <img src="figures/LinearQuadraticGraphics/Inequalities-5"/> </figure> <figure xml:id="fig_graphineq2"> <caption>The solution to
-                <m>f(x) \geq g(x)</m></caption> <img src="figures/LinearQuadraticGraphics/Inequalities-6"/> </figure>
+                <m>f(x)\lt g(x)</m></caption> <image source="figures/LinearQuadraticGraphics/Inequalities-5"></image> </figure> <figure xml:id="fig_graphineq2"> <caption>The solution to
+                <m>f(x) \geq g(x)</m></caption> <image source="figures/LinearQuadraticGraphics/Inequalities-6"></image> </figure>
               </p>
             </li>
           </ol>
@@ -292,7 +292,7 @@
 
     <figure xml:id="fig_absvalineq">
       <caption>Solving <m>\lvert x\rvert \lt c</m> graphically</caption>
-      <img src="figures/LinearQuadraticGraphics/Inequalities-7"/>
+      <image source="figures/LinearQuadraticGraphics/Inequalities-7"></image>
     </figure>
 
     <p>
@@ -348,7 +348,7 @@
                 in interval notation is <m>(-\infty,-2] \cup [4,\infty)</m>.
                 Graphically,
                 we have <xref ref="fig_absvalineqeg1">Figure</xref>. <figure xml:id="fig_absvalineqeg1"> <caption>Solving
-                <m>\lvert x-1\rvert \geq 3</m> in <xref ref="ex_absvalineq">Example</xref></caption> <img src="figures/LinearQuadraticGraphics/Inequalities-8"/> </figure> We see that the graph of <m>y=|x-1|</m> is above the horizontal line <m>y=3</m> for
+                <m>\lvert x-1\rvert \geq 3</m> in <xref ref="ex_absvalineq">Example</xref></caption> <image source="figures/LinearQuadraticGraphics/Inequalities-8"></image> </figure> We see that the graph of <m>y=|x-1|</m> is above the horizontal line <m>y=3</m> for
                 <m>x \lt -2</m> and <m>x > 4</m> hence this is where <m>|x-1| > 3</m>.
                 The two graphs intersect when <m>x=-2</m> and <m>x=4</m>,
                 so we have graphical confirmation of our analytic solution.
@@ -368,7 +368,7 @@
                 Graphically we see in <xref ref="fig_absvalineqeg2">Figure</xref>
                 that the graph of <m>y=4-3|2x+1|</m> is above <m>y=-2</m> for <m>x</m> values between <m>-\frac{3}{2}</m> and
                 <m>\frac{1}{2}</m>. <figure xml:id="fig_absvalineqeg2"> <caption>Solving
-                <m>4 - 3|2x+1| > -2</m> in <xref ref="ex_absvalineq">Example</xref></caption> <img src="figures/LinearQuadraticGraphics/Inequalities-9"/> </figure>
+                <m>4 - 3|2x+1| > -2</m> in <xref ref="ex_absvalineq">Example</xref></caption> <image source="figures/LinearQuadraticGraphics/Inequalities-9"></image> </figure>
               </p>
             </li>
 
@@ -396,7 +396,7 @@
                 the horizontal lines <m>y=2</m> and <m>y=5</m> for <m>x</m> values between <m>-4</m> and <m>-1</m> as well as those between <m>3</m> and <m>6</m>.
                 Including the <m>x</m> values where <m>y=|x-1|</m> and <m>y=5</m> intersect,
                 we get <xref ref="fig_absvalineqeg3">Figure</xref>. <figure xml:id="fig_absvalineqeg3"> <caption>Solving
-                <m>2 \lt |x-1| \leq 5</m> in <xref ref="ex_absvalineq">Example</xref></caption> <img src="figures/LinearQuadraticGraphics/Inequalities-10"/> </figure>
+                <m>2 \lt |x-1| \leq 5</m> in <xref ref="ex_absvalineq">Example</xref></caption> <image source="figures/LinearQuadraticGraphics/Inequalities-10"></image> </figure>
               </p>
             </li>
 
@@ -427,7 +427,7 @@
                 we accept all of these solutions as well.
                 Our final answer is
           <m>(-\infty, -2] \cup [2,\infty)</m>. <figure xml:id="fig_absvalineqeg4"> <caption>Solving
-                <m>|x+1|\geq \dfrac{x+4}{2}</m> in <xref ref="ex_absvalineq">Example</xref></caption> <img src="figures/LinearQuadraticGraphics/Inequalities-11"/> </figure>
+                <m>|x+1|\geq \dfrac{x+4}{2}</m> in <xref ref="ex_absvalineq">Example</xref></caption> <image source="figures/LinearQuadraticGraphics/Inequalities-11"></image> </figure>
               </p>
             </li>
           </ol>
@@ -450,7 +450,7 @@
 
     <figure xml:id="fig_parabineq0">
       <caption><m>y=x^2-x-6</m></caption>
-      <img src="figures/LinearQuadraticGraphics/Inequalities-12"/>
+      <image source="figures/LinearQuadraticGraphics/Inequalities-12"></image>
     </figure>
   </introduction>
 
@@ -474,7 +474,7 @@
     </p>
 
     <p>
-      <img src="figures/LinearQuadraticGraphics/Inequalities-13"/>
+      <image source="figures/LinearQuadraticGraphics/Inequalities-13"></image>
     </p>
 
     <p>
@@ -613,13 +613,13 @@
                 </aside>
                 <figure xml:id="fig_quadineqeg1">
                   <caption>The sign diagram for <m>f(x)=2x^2+x-3</m></caption>
-                  <img src="figures/LinearQuadraticGraphics/Inequalities-14"/>
+                  <image source="figures/LinearQuadraticGraphics/Inequalities-14"></image>
                 </figure>
 
                 <figure xml:id="fig_quadineqeg2">
                   <caption>Verifying the solution to
                 <m>2x^2\leq 3-x</m> graphically</caption>
-                  <img src="figures/LinearQuadraticGraphics/Inequalities-15"/>
+                  <image source="figures/LinearQuadraticGraphics/Inequalities-15"></image>
                 </figure>
 
                 To verify our solution graphically,
@@ -688,10 +688,10 @@
                 Finding tangent lines to arbitrary functions is a fundamental problem solved,
                 in general,
                 with Calculus. <figure xml:id="fig_quadineqeg3"> <caption>The sign diagram for
-          <m>f(x)=x^2-2x-1</m></caption> <img src="figures/LinearQuadraticGraphics/Inequalities-16"/> </figure> <figure xml:id="fig_quadineqeg4"> <caption>Verifying the solution to
-          <m>x^2-2x > 1</m> graphically</caption> <img src="figures/LinearQuadraticGraphics/Inequalities-17"/> </figure> <figure xml:id="fig_quadineqeg5"> <caption>The sign diagram for
-                <m>f(x)=x^2-2x+1</m></caption> <img src="figures/LinearQuadraticGraphics/Inequalities-18"/> </figure> <figure xml:id="fig_quadineqeg6"> <caption>Verifying the solution to
-                <m>x^2+1\leq 2x</m> graphically</caption> <img src="figures/LinearQuadraticGraphics/Inequalities-19"/> </figure>
+          <m>f(x)=x^2-2x-1</m></caption> <image source="figures/LinearQuadraticGraphics/Inequalities-16"></image> </figure> <figure xml:id="fig_quadineqeg4"> <caption>Verifying the solution to
+          <m>x^2-2x > 1</m> graphically</caption> <image source="figures/LinearQuadraticGraphics/Inequalities-17"></image> </figure> <figure xml:id="fig_quadineqeg5"> <caption>The sign diagram for
+                <m>f(x)=x^2-2x+1</m></caption> <image source="figures/LinearQuadraticGraphics/Inequalities-18"></image> </figure> <figure xml:id="fig_quadineqeg6"> <caption>Verifying the solution to
+                <m>x^2+1\leq 2x</m> graphically</caption> <image source="figures/LinearQuadraticGraphics/Inequalities-19"></image> </figure>
               </p>
             </li>
 
@@ -727,8 +727,8 @@
                 yielding the sign diagram in <xref ref="fig_quadineqeg8">Figure</xref>.
                 Hence, our solution to <m>g(x) = x^2-x-2 \leq 0</m>,
                 in this region is <m>[1,2)</m>. <figure xml:id="fig_quadineqeg7"> <caption>The sign diagram for <m>f(x)=x^2-3x</m>,
-                where <m>x\lt 1</m></caption> <img src="figures/LinearQuadraticGraphics/Inequalities-20"/> </figure> <figure xml:id="fig_quadineqeg8"> <caption>The sign diagram for <m>g(x)=x^2-x-2</m>,
-                where <m>x\geq 1</m></caption> <img src="figures/LinearQuadraticGraphics/Inequalities-21"/> </figure> Combining these into one sign diagram,
+                where <m>x\lt 1</m></caption> <image source="figures/LinearQuadraticGraphics/Inequalities-20"></image> </figure> <figure xml:id="fig_quadineqeg8"> <caption>The sign diagram for <m>g(x)=x^2-x-2</m>,
+                where <m>x\geq 1</m></caption> <image source="figures/LinearQuadraticGraphics/Inequalities-21"></image> </figure> Combining these into one sign diagram,
                 we have that our solution is <m>[0,2]</m>.
                 Graphically, to check <m>2x-x^2 \geq |x-1|-1</m>,
                 we set <m>h(x) = 2x-x^2</m> and
@@ -756,12 +756,12 @@
 
     <figure xml:id="fig_quadineqeg9">
       <caption>The overall sign diagram for Problem 4 in <xref ref="ex_quadineq">Example</xref></caption>
-      <img src="figures/LinearQuadraticGraphics/Inequalities-22"/>
+      <image source="figures/LinearQuadraticGraphics/Inequalities-22"></image>
     </figure>
 
     <figure xml:id="fig_quadineqeglast">
       <caption>Verifying the inequality <m>2x-x^2\geq \lvert x-1\rvert -1</m> graphically</caption>
-      <img src="figures/LinearQuadraticGraphics/Inequalities-23"/>
+      <image source="figures/LinearQuadraticGraphics/Inequalities-23"></image>
     </figure>
 
     <example xml:id="ex_tolerance">
@@ -871,7 +871,7 @@
                 its <m>y</m>-coordinate must be less than or equal to the <m>y</m>-coordinate on the parabola <m>y=2-x^2</m>.
                 This is the set of all points <em>below</em>
                 or <em>on</em> the parabola <m>y=2-x^2</m>:
-                see <xref ref="fig_ineqrel2">Figure</xref>. <figure xml:id="fig_ineqrel1"> <caption>Graph of the relation <m>R</m> in <xref ref="ex_ineqrels">Example</xref></caption> <img src="figures/LinearQuadraticGraphics/Inequalities-24"/> </figure> <figure xml:id="fig_ineqrel2"> <caption>Graph of the relation <m>S</m> in <xref ref="ex_ineqrels">Example</xref></caption> <img src="figures/LinearQuadraticGraphics/Inequalities-25"/> </figure>
+                see <xref ref="fig_ineqrel2">Figure</xref>. <figure xml:id="fig_ineqrel1"> <caption>Graph of the relation <m>R</m> in <xref ref="ex_ineqrels">Example</xref></caption> <image source="figures/LinearQuadraticGraphics/Inequalities-24"></image> </figure> <figure xml:id="fig_ineqrel2"> <caption>Graph of the relation <m>S</m> in <xref ref="ex_ineqrels">Example</xref></caption> <image source="figures/LinearQuadraticGraphics/Inequalities-25"></image> </figure>
               </p>
             </li>
 
@@ -887,7 +887,7 @@
                 so we set <m>|x| = 2-x^2</m>.
                 Proceeding as before,
                 breaking this equation into cases, we get <m>x=-1,1</m>.
-                Graphing yields <xref ref="fig_ineqrel3">Figure</xref>. <figure xml:id="fig_ineqrel3"> <caption>Graph of the relation <m>T</m> in <xref ref="ex_ineqrels">Example</xref></caption> <img src="figures/LinearQuadraticGraphics/Inequalities-26"/> </figure>
+                Graphing yields <xref ref="fig_ineqrel3">Figure</xref>. <figure xml:id="fig_ineqrel3"> <caption>Graph of the relation <m>T</m> in <xref ref="ex_ineqrels">Example</xref></caption> <image source="figures/LinearQuadraticGraphics/Inequalities-26"></image> </figure>
               </p>
             </li>
           </ol>
@@ -1482,7 +1482,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/LinearQuadraticGraphics/Inequalities-27"/>
+          <image source="figures/LinearQuadraticGraphics/Inequalities-27"></image>
         </p>
       </answer>
     </exercise>
@@ -1494,7 +1494,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/LinearQuadraticGraphics/Inequalities-28"/>
+          <image source="figures/LinearQuadraticGraphics/Inequalities-28"></image>
         </p>
       </answer>
     </exercise>
@@ -1506,7 +1506,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/LinearQuadraticGraphics/Inequalities-29"/>
+          <image source="figures/LinearQuadraticGraphics/Inequalities-29"></image>
         </p>
       </answer>
     </exercise>
@@ -1518,7 +1518,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/LinearQuadraticGraphics/Inequalities-30"/>
+          <image source="figures/LinearQuadraticGraphics/Inequalities-30"></image>
         </p>
       </answer>
     </exercise>
@@ -1530,7 +1530,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/LinearQuadraticGraphics/Inequalities-31"/>
+          <image source="figures/LinearQuadraticGraphics/Inequalities-31"></image>
         </p>
       </answer>
     </exercise>
@@ -1542,7 +1542,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/LinearQuadraticGraphics/Inequalities-32"/>
+          <image source="figures/LinearQuadraticGraphics/Inequalities-32"></image>
         </p>
       </answer>
     </exercise>

--- a/ptx/IntroExpLogs.ptx
+++ b/ptx/IntroExpLogs.ptx
@@ -128,7 +128,7 @@
         <cell></cell>
       </row>
       <row>
-        <cell><img src="figures/ExpLogsGraphics/IntroExpLogs-1"/></cell>
+        <cell><image source="figures/ExpLogsGraphics/IntroExpLogs-1"></image></cell>
       </row>
       </tabular>
     </table>
@@ -258,7 +258,7 @@
       <caption>Reflecting <m>y=2^x</m> across the <m>y</m>-axis to obtain the graph <m>y=2^{-x}</m></caption>
       <tabular>
         <row>
-          <cell><img src="figures/ExpLogsGraphics/IntroExpLogs-2"/></cell>
+          <cell><image source="figures/ExpLogsGraphics/IntroExpLogs-2"></image></cell>
         </row>
         <row>
           <cell>(a) <m>y=f(x)=2^x</m></cell>
@@ -267,7 +267,7 @@
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/ExpLogsGraphics/IntroExpLogs-3"/></cell>
+          <cell><image source="figures/ExpLogsGraphics/IntroExpLogs-3"></image></cell>
         </row>
         <row>
           <cell>(b) <m>y=g(x)=f(-x)=2^{-x}</m></cell>
@@ -350,7 +350,7 @@
                 <li>
                   <p>
                     The graph of <m>f</m> resembles:
-                    <img src="figures/ExpLogsGraphics/IntroExpLogs-4"/> <m>y = b^{x}</m>,
+                    <image source="figures/ExpLogsGraphics/IntroExpLogs-4"></image> <m>y = b^{x}</m>,
                     <m>b > 1</m>
                   </p>
                 </li>
@@ -388,7 +388,7 @@
                 <li>
                   <p>
                     The graph of <m>f</m> resembles:
-                    <img src="figures/ExpLogsGraphics/IntroExpLogs-5"/>
+                    <image source="figures/ExpLogsGraphics/IntroExpLogs-5"></image>
                     <m>y = b^{x}</m>, <m>0 \lt b \lt 1</m>
                   </p>
                 </li>
@@ -481,7 +481,7 @@
                 The horizontal asymptote remains <m>y=0</m>.
                 Finally, we restrict the domain to
                 <m>[0,\infty)</m> to fit with the applied domain given to us.
-                We have the result in <xref ref="fig_introexp3">Figure</xref>. <table xml:id="fig_introexp3"> <caption>The graph <m>y=V(x)</m> in <xref ref="cardepreciationex">Example</xref></caption> <tabular> <row> <cell><img src="figures/ExpLogsGraphics/IntroExpLogs-6"/></cell> </row> <row> <cell><m>y=f(x)=\left(\frac{4}{5}\right)^x</m></cell> </row> <row> <cell></cell> </row> <row> <cell><m>\boldsymbol{\downarrow}</m></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/ExpLogsGraphics/IntroExpLogs-7"/></cell> </row> <row> <cell><m>y=V(x)=25f(x)</m>,
+                We have the result in <xref ref="fig_introexp3">Figure</xref>. <table xml:id="fig_introexp3"> <caption>The graph <m>y=V(x)</m> in <xref ref="cardepreciationex">Example</xref></caption> <tabular> <row> <cell><image source="figures/ExpLogsGraphics/IntroExpLogs-6"></image></cell> </row> <row> <cell><m>y=f(x)=\left(\frac{4}{5}\right)^x</m></cell> </row> <row> <cell></cell> </row> <row> <cell><m>\boldsymbol{\downarrow}</m></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/ExpLogsGraphics/IntroExpLogs-7"></image></cell> </row> <row> <cell><m>y=V(x)=25f(x)</m>,
                 <m>x\geq 0</m></cell> </row> </tabular> </table>
               </p>
             </li>
@@ -594,7 +594,7 @@
                   <caption>Graphing <m>T(t)</m> in <xref ref="exptempex">Example</xref></caption>
                   <tabular>
                     <row>
-                      <cell><img src="figures/ExpLogsGraphics/IntroExpLogs-8"/></cell>
+                      <cell><image source="figures/ExpLogsGraphics/IntroExpLogs-8"></image></cell>
                     </row>
                     <row>
                       <cell><m>y=f(t)=e^t</m></cell>
@@ -609,7 +609,7 @@
                       <cell></cell>
                     </row>
                     <row>
-                      <cell><img src="figures/ExpLogsGraphics/IntroExpLogs-9"/></cell>
+                      <cell><image source="figures/ExpLogsGraphics/IntroExpLogs-9"></image></cell>
                     </row>
                     <row>
                       <cell><m>y=T(t)</m></cell>
@@ -726,13 +726,13 @@
       <caption>The logarithm is the inverse of the exponential function</caption>
       <tabular>
         <row>
-          <cell><img src="figures/ExpLogsGraphics/IntroExpLogs-10"/></cell>
+          <cell><image source="figures/ExpLogsGraphics/IntroExpLogs-10"></image></cell>
         </row>
         <row>
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/ExpLogsGraphics/IntroExpLogs-11"/></cell>
+          <cell><image source="figures/ExpLogsGraphics/IntroExpLogs-11"></image></cell>
         </row>
       </tabular>
     </table>
@@ -828,7 +828,7 @@
               </ul>
             </p>
 
-            <img src="figures/ExpLogsGraphics/IntroExpLogs-12"/></li>
+            <image source="figures/ExpLogsGraphics/IntroExpLogs-12"></image></li>
         </ul>
 
         <ul>
@@ -865,7 +865,7 @@
               </ul>
             </p>
 
-            <img src="figures/ExpLogsGraphics/IntroExpLogs-13"/></li>
+            <image source="figures/ExpLogsGraphics/IntroExpLogs-13"></image></li>
         </ul>
       </statement>
     </theorem>
@@ -1098,7 +1098,7 @@
                 Next,
           we multiply the <m>y</m>-coordinates by <m>2</m> which results in a vertical stretch by a factor of <m>2</m>,
                 then we finish by subtracting <m>1</m> from the <m>y</m>-coordinates which shifts the graph down <m>1</m> unit.
-                We leave it to the reader to perform the indicated arithmetic on the points themselves and to verify the graph produced by the calculator below. <figure xml:id="fig_introexp6"> <caption><m>y=f(x)=2\log(3-x)-1</m></caption> <img src="figures/ExpLogsGraphics/ExpLogs01"/> </figure>
+                We leave it to the reader to perform the indicated arithmetic on the points themselves and to verify the graph produced by the calculator below. <figure xml:id="fig_introexp6"> <caption><m>y=f(x)=2\log(3-x)-1</m></caption> <image source="figures/ExpLogsGraphics/ExpLogs01"></image> </figure>
               </p>
             </li>
 
@@ -1111,7 +1111,7 @@
                 we find <m>r</m> is undefined at <m>x=1</m> and <m>r(x) = 0</m> when <m>x=0</m>.
                 Choosing some test values,
                 we generate the sign diagram in <xref ref="fig_introexpsd1">Figure</xref>. <figure xml:id="fig_introexpsd1"> <caption>Sign diagram for
-                <m>r(x) = \frac{x}{x-1}</m></caption> <img src="figures/ExpLogsGraphics/IntroExpLogs-14"/> </figure> We find <m>\frac{x}{x-1} > 0</m> on
+                <m>r(x) = \frac{x}{x-1}</m></caption> <image source="figures/ExpLogsGraphics/IntroExpLogs-14"></image> </figure> We find <m>\frac{x}{x-1} > 0</m> on
                 <m>(-\infty, 0) \cup (1, \infty)</m> to get the domain of <m>g</m>.
                 The graph of <m>y=g(x)</m> in <xref ref="fig_introexp7">Figure</xref> confirms this.
                 We can tell from the graph of <m>g</m> that it is not the result of <xref ref="Transformations">Section</xref>
@@ -1127,7 +1127,7 @@
                 we know that as <m>x \rightarrow \pm \infty</m>,
                 <m>\frac{x}{x-1} \approx 1</m>.
                 Hence, it makes sense that
-                <m>g(x) = \ln \left(\frac{x}{x-1}\right) \approx \ln(1) = 0</m>. <figure xml:id="fig_introexp7"> <caption><m>y=g(x)=\ln\left(\frac{x}{x-1}\right)</m></caption> <img src="figures/ExpLogsGraphics/ExpLogs02"/> </figure>
+                <m>g(x) = \ln \left(\frac{x}{x-1}\right) \approx \ln(1) = 0</m>. <figure xml:id="fig_introexp7"> <caption><m>y=g(x)=\ln\left(\frac{x}{x-1}\right)</m></caption> <image source="figures/ExpLogsGraphics/ExpLogs02"></image> </figure>
               </p>
             </li>
           </ol>
@@ -1208,7 +1208,7 @@
                 namely <m>(-\infty, \infty)</m>,
                 but that the range of <m>f</m> is
                 <m>(-3, \infty)</m>. <table xml:id="fig_introexp8"> <caption>Graphing
-                <m>f(x)=2^{x-1}-3</m> in <xref ref="proceduralinverse">Example</xref></caption> <tabular> <row> <cell><img src="figures/ExpLogsGraphics/IntroExpLogs-15"/></cell> </row> <row> <cell><m>y=h(x)=2^x</m></cell> </row> <row> <cell></cell> </row> <row> <cell><m>\boldsymbol{\downarrow}</m></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/ExpLogsGraphics/IntroExpLogs-16"/></cell> </row> <row> <cell><m>y=f(x)=2^{x-1}-3</m></cell> </row> </tabular> </table>
+                <m>f(x)=2^{x-1}-3</m> in <xref ref="proceduralinverse">Example</xref></caption> <tabular> <row> <cell><image source="figures/ExpLogsGraphics/IntroExpLogs-15"></image></cell> </row> <row> <cell><m>y=h(x)=2^x</m></cell> </row> <row> <cell></cell> </row> <row> <cell><m>\boldsymbol{\downarrow}</m></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/ExpLogsGraphics/IntroExpLogs-16"></image></cell> </row> <row> <cell><m>y=f(x)=2^{x-1}-3</m></cell> </row> </tabular> </table>
               </p>
             </li>
 
@@ -1300,7 +1300,7 @@
                 which matches the range of <m>f</m>,
                 and the range of <m>f^{-1}</m> is <m>(-\infty, \infty)</m>,
                 which matches the domain of <m>f</m>. <table xml:id="fig_introexp9"> <caption>Graphing
-                <m>f^{-1}(x)=\log_2(x+3)+1</m> in <xref ref="proceduralinverse">Example</xref></caption> <tabular> <row> <cell><img src="figures/ExpLogsGraphics/IntroExpLogs-17"/></cell> </row> <row> <cell><m>y=j(x)=\log_2(x)</m></cell> </row> <row> <cell></cell> </row> <row> <cell><m>\boldsymbol{\downarrow}</m></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/ExpLogsGraphics/IntroExpLogs-18"/></cell> </row> <row> <cell><m>y=f^{-1}(x)=\log_2(x+3)+1</m></cell> </row> </tabular> </table>
+                <m>f^{-1}(x)=\log_2(x+3)+1</m> in <xref ref="proceduralinverse">Example</xref></caption> <tabular> <row> <cell><image source="figures/ExpLogsGraphics/IntroExpLogs-17"></image></cell> </row> <row> <cell><m>y=j(x)=\log_2(x)</m></cell> </row> <row> <cell></cell> </row> <row> <cell><m>\boldsymbol{\downarrow}</m></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/ExpLogsGraphics/IntroExpLogs-18"></image></cell> </row> <row> <cell><m>y=f^{-1}(x)=\log_2(x+3)+1</m></cell> </row> </tabular> </table>
               </p>
             </li>
 
@@ -1335,7 +1335,7 @@
                 Last, but certainly not least,
                 we graph <m>y=f(x)</m> and
                 <m>y=f^{-1}(x)</m> on the same set of axes and see the symmetry about the line <m>y=x</m> in <xref ref="fig_introexp10">Figure</xref>
-                <figure xml:id="fig_introexp10"> <caption>The graphs of <m>f</m> and <m>f^{-1}</m> in <xref ref="proceduralinverse">Example</xref></caption> <img src="figures/ExpLogsGraphics/IntroExpLogs-19"/> </figure>
+                <figure xml:id="fig_introexp10"> <caption>The graphs of <m>f</m> and <m>f^{-1}</m> in <xref ref="proceduralinverse">Example</xref></caption> <image source="figures/ExpLogsGraphics/IntroExpLogs-19"></image> </figure>
               </p>
             </li>
           </ol>
@@ -2066,7 +2066,7 @@
         </p>
 
         <p>
-          <img src="figures/ExpLogsGraphics/IntroExpLogs-20"/>
+          <image source="figures/ExpLogsGraphics/IntroExpLogs-20"></image>
         </p>
       </answer>
     </exercise>
@@ -2087,7 +2087,7 @@
         </p>
 
         <p>
-          <img src="figures/ExpLogsGraphics/IntroExpLogs-21"/>
+          <image source="figures/ExpLogsGraphics/IntroExpLogs-21"></image>
         </p>
       </answer>
     </exercise>
@@ -2107,7 +2107,7 @@
         </p>
 
         <p>
-          <img src="figures/ExpLogsGraphics/IntroExpLogs-22"/>
+          <image source="figures/ExpLogsGraphics/IntroExpLogs-22"></image>
         </p>
       </answer>
     </exercise>
@@ -2127,7 +2127,7 @@
         </p>
 
         <p>
-          <img src="figures/ExpLogsGraphics/IntroExpLogs-23"/>
+          <image source="figures/ExpLogsGraphics/IntroExpLogs-23"></image>
         </p>
       </answer>
     </exercise>
@@ -2147,7 +2147,7 @@
         </p>
 
         <p>
-          <img src="figures/ExpLogsGraphics/IntroExpLogs-24"/>
+          <image source="figures/ExpLogsGraphics/IntroExpLogs-24"></image>
         </p>
       </answer>
     </exercise>
@@ -2167,7 +2167,7 @@
         </p>
 
         <p>
-          <img src="figures/ExpLogsGraphics/IntroExpLogs-25"/>
+          <image source="figures/ExpLogsGraphics/IntroExpLogs-25"></image>
         </p>
       </answer>
     </exercise>
@@ -2194,7 +2194,7 @@
         </p>
 
         <p>
-          <img src="figures/ExpLogsGraphics/IntroExpLogs-26"/>
+          <image source="figures/ExpLogsGraphics/IntroExpLogs-26"></image>
         </p>
       </answer>
     </exercise>
@@ -2215,7 +2215,7 @@
         </p>
 
         <p>
-          <img src="figures/ExpLogsGraphics/IntroExpLogs-27"/>
+          <image source="figures/ExpLogsGraphics/IntroExpLogs-27"></image>
         </p>
       </answer>
     </exercise>
@@ -2235,7 +2235,7 @@
         </p>
 
         <p>
-          <img src="figures/ExpLogsGraphics/IntroExpLogs-28"/>
+          <image source="figures/ExpLogsGraphics/IntroExpLogs-28"></image>
         </p>
       </answer>
     </exercise>
@@ -2255,7 +2255,7 @@
         </p>
 
         <p>
-          <img src="figures/ExpLogsGraphics/IntroExpLogs-29"/>
+          <image source="figures/ExpLogsGraphics/IntroExpLogs-29"></image>
         </p>
       </answer>
     </exercise>
@@ -2275,7 +2275,7 @@
         </p>
 
         <p>
-          <img src="figures/ExpLogsGraphics/IntroExpLogs-30"/>
+          <image source="figures/ExpLogsGraphics/IntroExpLogs-30"></image>
         </p>
       </answer>
     </exercise>
@@ -2295,7 +2295,7 @@
         </p>
 
         <p>
-          <img src="figures/ExpLogsGraphics/IntroExpLogs-31"/>
+          <image source="figures/ExpLogsGraphics/IntroExpLogs-31"></image>
         </p>
       </answer>
     </exercise>
@@ -2331,7 +2331,7 @@
         </p>
 
         <p>
-          <img src="figures/ExpLogsGraphics/IntroExpLogs-32"/>
+          <image source="figures/ExpLogsGraphics/IntroExpLogs-32"></image>
         </p>
       </answer>
     </exercise>
@@ -2351,7 +2351,7 @@
         </p>
 
         <p>
-          <img src="figures/ExpLogsGraphics/IntroExpLogs-33"/>
+          <image source="figures/ExpLogsGraphics/IntroExpLogs-33"></image>
         </p>
       </answer>
     </exercise>
@@ -2371,7 +2371,7 @@
         </p>
 
         <p>
-          <img src="figures/ExpLogsGraphics/IntroExpLogs-34"/>
+          <image source="figures/ExpLogsGraphics/IntroExpLogs-34"></image>
         </p>
       </answer>
     </exercise>
@@ -2391,7 +2391,7 @@
         </p>
 
         <p>
-          <img src="figures/ExpLogsGraphics/IntroExpLogs-35"/>
+          <image source="figures/ExpLogsGraphics/IntroExpLogs-35"></image>
         </p>
       </answer>
     </exercise>

--- a/ptx/IntroPolar.ptx
+++ b/ptx/IntroPolar.ptx
@@ -201,7 +201,7 @@
               <m>240^{\circ}</m> then move out <m>2</m> units from the pole,
               we plot <m>P\left(2, 240^{\circ}\right)</m> in <xref ref="fig_polar7">Figure</xref>
               below. <!-- <caption>Plotting
-              <m>P(2,240^\circ)</m></caption> --> <sidebyside> <tabular> <row> <cell><img src="figures/AppExtGraphics/IntroPolar-21"/></cell> <cell><img src="figures/AppExtGraphics/IntroPolar-22"/></cell> </row> </tabular> </sidebyside> We now set about finding alternate descriptions
+              <m>P(2,240^\circ)</m></caption> --> <sidebyside> <tabular> <row> <cell><image source="figures/AppExtGraphics/IntroPolar-21"></image></cell> <cell><image source="figures/AppExtGraphics/IntroPolar-22"></image></cell> </row> </tabular> </sidebyside> We now set about finding alternate descriptions
               <m>(r,\theta)</m> for the point <m>P</m>.
               Since <m>P</m> is <m>2</m> units from the pole, <m>r = \pm 2</m>.
               Next, we choose angles <m>\theta</m> for each of the <m>r</m> values.
@@ -215,7 +215,7 @@
               <m>\theta = 60^{\circ}</m> to arrive at location coterminal with <m>240^{\circ}</m>.
               Hence, our answer here is <m>\left(-2,60^{\circ}\right)</m>.
               We check our answers by plotting them in <xref ref="fig_polar8">Figure</xref>. <!-- <caption>Alternate polar reprentations of
-              <m>P(2,240^\circ)</m></caption> --> <sidebyside> <tabular> <row> <cell><img src="figures/AppExtGraphics/IntroPolar-23"/></cell> <cell><img src="figures/AppExtGraphics/IntroPolar-24"/></cell> </row> </tabular> </sidebyside>
+              <m>P(2,240^\circ)</m></caption> --> <sidebyside> <tabular> <row> <cell><image source="figures/AppExtGraphics/IntroPolar-23"></image></cell> <cell><image source="figures/AppExtGraphics/IntroPolar-24"></image></cell> </row> </tabular> </sidebyside>
             </p>
             </li>
 
@@ -226,7 +226,7 @@
               Since <m>r = -4 \lt 0</m>,
               we find our point lies <m>4</m> units from the pole on the terminal side of
               <m>\frac{\pi}{6}</m>. <!-- <caption>Plotting
-              <m>P(-4,\frac{7\pi}{6})</m></caption> --> <sidebyside> <tabular> <row> <cell><img src="figures/AppExtGraphics/IntroPolar-25"/></cell> <cell><img src="figures/AppExtGraphics/IntroPolar-26"/></cell> </row> </tabular> </sidebyside> To find alternate descriptions for <m>P</m>,
+              <m>P(-4,\frac{7\pi}{6})</m></caption> --> <sidebyside> <tabular> <row> <cell><image source="figures/AppExtGraphics/IntroPolar-25"></image></cell> <cell><image source="figures/AppExtGraphics/IntroPolar-26"></image></cell> </row> </tabular> </sidebyside> To find alternate descriptions for <m>P</m>,
               we note that the distance from <m>P</m> to the pole is <m>4</m> units,
               so any representation
           <m>(r,\theta)</m> for <m>P</m> must have <m>r = \pm 4</m>.
@@ -238,7 +238,7 @@
               we may choose any angle coterminal with the angle in the original representation of <m>P</m> <m>\left(-4, \frac{7\pi}{6}\right)</m>.
               We pick <m>-\frac{5\pi}{6}</m> and get
               <m>\left(-4, -\frac{5 \pi}{6}\right)</m> as our second answer. <!-- <caption>Alternate polar representations of
-              <m>P(-4,\frac{7\pi}{6})</m></caption> --> <sidebyside> <tabular> <row> <cell><img src="figures/AppExtGraphics/IntroPolar-27"/></cell> <cell><img src="figures/AppExtGraphics/IntroPolar-28"/></cell> </row> </tabular> </sidebyside>
+              <m>P(-4,\frac{7\pi}{6})</m></caption> --> <sidebyside> <tabular> <row> <cell><image source="figures/AppExtGraphics/IntroPolar-27"></image></cell> <cell><image source="figures/AppExtGraphics/IntroPolar-28"></image></cell> </row> </tabular> </sidebyside>
             </p>
             </li>
 
@@ -249,7 +249,7 @@
               we move along the polar axis <m>117</m> units from the pole and rotate <em>clockwise</em>
               <m>\frac{5\pi}{2}</m> radians as illustrated in <xref ref="fig_polar11">Figure</xref>
               below. <!-- <caption>Plotting
-              <m>P(117,-\frac{5\pi}{2})</m></caption> --> <sidebyside> <tabular> <row> <cell><img src="figures/AppExtGraphics/IntroPolar-29"/></cell> <cell><img src="figures/AppExtGraphics/IntroPolar-30"/></cell> </row> </tabular> </sidebyside> Since <m>P</m> is <m>117</m> units from the pole,
+              <m>P(117,-\frac{5\pi}{2})</m></caption> --> <sidebyside> <tabular> <row> <cell><image source="figures/AppExtGraphics/IntroPolar-29"></image></cell> <cell><image source="figures/AppExtGraphics/IntroPolar-30"></image></cell> </row> </tabular> </sidebyside> Since <m>P</m> is <m>117</m> units from the pole,
               any representation <m>(r,\theta)</m> for <m>P</m> satisfies <m>r = \pm 117</m>.
               For the <m>r=117</m> case,
               we can take <m>\theta</m> to be any angle coterminal with <m>-\frac{5\pi}{2}</m>.
@@ -260,7 +260,7 @@
               We find that <m>\theta = \frac{\pi}{2}</m> satisfies this requirement,
               so our second answer is
           <m>\left(-117, \frac{\pi}{2}\right)</m>. <!-- <caption>Alternate polar representations of
-              <m>P(117,-\frac{5\pi}{2})</m></caption> --> <sidebyside> <tabular> <row> <cell><img src="figures/AppExtGraphics/IntroPolar-31"/></cell> <cell><img src="figures/AppExtGraphics/IntroPolar-32"/></cell> </row> </tabular> </sidebyside>
+              <m>P(117,-\frac{5\pi}{2})</m></caption> --> <sidebyside> <tabular> <row> <cell><image source="figures/AppExtGraphics/IntroPolar-31"></image></cell> <cell><image source="figures/AppExtGraphics/IntroPolar-32"></image></cell> </row> </tabular> </sidebyside>
             </p>
             </li>
 
@@ -271,13 +271,13 @@
               <m>\frac{\pi}{4}</m> radians to plot <m>P\left(-3, -\frac{\pi}{4} \right)</m>.
               We see that <m>P</m> lies on the terminal side of
           <m>\frac{3\pi}{4}</m>. <!-- <caption>Plotting
-              <m>P(-3,-\frac{\pi}{4})</m></caption> --> <sidebyside> <tabular> <row> <cell><img src="figures/AppExtGraphics/IntroPolar-33"/></cell> <cell><img src="figures/AppExtGraphics/IntroPolar-34"/></cell> </row> </tabular> </sidebyside> Since <m>P</m> lies on the terminal side of <m>\frac{3\pi}{4}</m>,
+              <m>P(-3,-\frac{\pi}{4})</m></caption> --> <sidebyside> <tabular> <row> <cell><image source="figures/AppExtGraphics/IntroPolar-33"></image></cell> <cell><image source="figures/AppExtGraphics/IntroPolar-34"></image></cell> </row> </tabular> </sidebyside> Since <m>P</m> lies on the terminal side of <m>\frac{3\pi}{4}</m>,
               one alternative representation for <m>P</m> is <m>\left(3, \frac{3\pi}{4}\right)</m>.
               To find a different representation for <m>P</m> with <m>r=-3</m>,
               we may choose any angle coterminal with <m>-\frac{\pi}{4}</m>.
               We choose <m>\theta = \frac{7\pi}{4}</m> for our final answer
               <m>\left(-3, \frac{7\pi}{4} \right)</m>. <!-- <caption>Alternate polar representations of
-              <m>P(-3,-\frac{\pi}{4})</m></caption> --> <sidebyside> <tabular> <row> <cell><img src="figures/AppExtGraphics/IntroPolar-35"/></cell> <cell><img src="figures/AppExtGraphics/IntroPolar-36"/></cell> </row> </tabular> </sidebyside>
+              <m>P(-3,-\frac{\pi}{4})</m></caption> --> <sidebyside> <tabular> <row> <cell><image source="figures/AppExtGraphics/IntroPolar-35"></image></cell> <cell><image source="figures/AppExtGraphics/IntroPolar-36"></image></cell> </row> </tabular> </sidebyside>
             </p>
             </li>
           </ol>
@@ -487,7 +487,7 @@
               To check, we convert <m>(r,\theta) = \left(4, \frac{5\pi}{3}\right)</m> back to rectangular coordinates and we find
               <m>x = r \cos(\theta) = 4 \cos\left(\frac{5\pi}{3}\right) = 4 \left(\frac{1}{2}\right) = 2</m> and <m>y = r \sin(\theta) = 4 \sin\left(\frac{5\pi}{3}\right) = 4 \left(-\frac{\sqrt{3}}{2}\right) = -2\sqrt{3}</m>,
               as required. <figure xml:id="fig_polar15"> <caption><m>P</m> has rectangular coordinates <m>(2,-2\sqrt{3})</m> and polar coordinates
-              <m>(4,\frac{5\pi}{3})</m></caption> <img src="figures/AppExtGraphics/IntroPolar-37"/> </figure>
+              <m>(4,\frac{5\pi}{3})</m></caption> <image source="figures/AppExtGraphics/IntroPolar-37"></image> </figure>
             </p>
           </li>
 
@@ -504,7 +504,7 @@
               Our final answer is <m>(r,\theta) = \left(3\sqrt{2}, \frac{5\pi}{4}\right)</m>.
               To check, we find <m>x = r\cos(\theta) = (3\sqrt{2}) \cos\left(\frac{5\pi}{4}\right) = (3\sqrt{2})\left(-\frac{\sqrt{2}}{2}\right) = -3</m> and <m>y = r\sin(\theta) = (3\sqrt{2}) \sin\left(\frac{5\pi}{4}\right) = (3\sqrt{2})\left(-\frac{\sqrt{2}}{2}\right) = -3</m>,
               so we are done. <figure xml:id="fig_polar16"> <caption><m>Q</m> has rectangular coordinates <m>(-3,-3)</m> and polar coordinates
-              <m>(3\sqrt{2},\frac{5\pi}{4})</m></caption> <img src="figures/AppExtGraphics/IntroPolar-38"/> </figure>
+              <m>(3\sqrt{2},\frac{5\pi}{4})</m></caption> <image source="figures/AppExtGraphics/IntroPolar-38"></image> </figure>
             </p>
           </li>
 
@@ -526,7 +526,7 @@
               so our answer is <m>\left(3, \frac{3\pi}{2}\right)</m>.
               To check, we note <m>x = r \cos(\theta) = 3 \cos\left( \frac{3\pi}{2}\right) = (3)(0) = 0</m> and
               <m>y = r \sin(\theta) = 3 \sin\left( \frac{3\pi}{2}\right) = 3(-1) = -3</m>. <figure xml:id="fig_polar17"> <caption><m>R</m> has rectangular coordinates <m>(0,-3)</m> and polar coordinates
-              <m>(-3,\frac{3\pi}{2})</m></caption> <img src="figures/AppExtGraphics/IntroPolar-39"/> </figure>
+              <m>(-3,\frac{3\pi}{2})</m></caption> <image source="figures/AppExtGraphics/IntroPolar-39"></image> </figure>
             </p>
           </li>
 
@@ -553,7 +553,7 @@
 
         <figure xml:id="fig_polar18">
           <caption><m>S</m> has rectangular coordinates <m>(-3,4)</m> and polar coordinates <m>(5,\pi-\arctan(\frac{4}{3}))</m></caption>
-          <img src="figures/AppExtGraphics/IntroPolar-40"/>
+          <image source="figures/AppExtGraphics/IntroPolar-40"></image>
         </figure>
       </solution>
     </example>
@@ -905,7 +905,7 @@
         </p>
 
         <p>
-          <img src="figures/AppExtGraphics/IntroPolar-41"/>
+          <image source="figures/AppExtGraphics/IntroPolar-41"></image>
         </p>
       </answer>
     </exercise>
@@ -925,7 +925,7 @@
         </p>
 
         <p>
-          <img src="figures/AppExtGraphics/IntroPolar-42"/>
+          <image source="figures/AppExtGraphics/IntroPolar-42"></image>
         </p>
       </answer>
     </exercise>
@@ -945,7 +945,7 @@
         </p>
 
         <p>
-          <img src="figures/AppExtGraphics/IntroPolar-43"/>
+          <image source="figures/AppExtGraphics/IntroPolar-43"></image>
         </p>
       </answer>
     </exercise>
@@ -965,7 +965,7 @@
         </p>
 
         <p>
-          <img src="figures/AppExtGraphics/IntroPolar-44"/>
+          <image source="figures/AppExtGraphics/IntroPolar-44"></image>
         </p>
       </answer>
     </exercise>
@@ -985,7 +985,7 @@
         </p>
 
         <p>
-          <img src="figures/AppExtGraphics/IntroPolar-45"/>
+          <image source="figures/AppExtGraphics/IntroPolar-45"></image>
         </p>
       </answer>
     </exercise>
@@ -1001,7 +1001,7 @@
         </p>
 
         <p>
-          <m>\left( 3, -\dfrac{13\pi}{4} \right), \, \left( 3, \dfrac{11\pi}{4} \right)</m> <img src="figures/AppExtGraphics/IntroPolar-46"/>
+          <m>\left( 3, -\dfrac{13\pi}{4} \right), \, \left( 3, \dfrac{11\pi}{4} \right)</m> <image source="figures/AppExtGraphics/IntroPolar-46"></image>
         </p>
       </answer>
     </exercise>
@@ -1021,7 +1021,7 @@
         </p>
 
         <p>
-          <img src="figures/AppExtGraphics/IntroPolar-47"/>
+          <image source="figures/AppExtGraphics/IntroPolar-47"></image>
         </p>
       </answer>
     </exercise>
@@ -1041,7 +1041,7 @@
         </p>
 
         <p>
-          <img src="figures/AppExtGraphics/IntroPolar-48"/>
+          <image source="figures/AppExtGraphics/IntroPolar-48"></image>
         </p>
       </answer>
     </exercise>
@@ -1061,7 +1061,7 @@
         </p>
 
         <p>
-          <img src="figures/AppExtGraphics/IntroPolar-49"/>
+          <image source="figures/AppExtGraphics/IntroPolar-49"></image>
         </p>
       </answer>
     </exercise>
@@ -1081,7 +1081,7 @@
         </p>
 
         <p>
-          <img src="figures/AppExtGraphics/IntroPolar-50"/>
+          <image source="figures/AppExtGraphics/IntroPolar-50"></image>
         </p>
       </answer>
     </exercise>
@@ -1101,7 +1101,7 @@
         </p>
 
         <p>
-          <img src="figures/AppExtGraphics/IntroPolar-51"/>
+          <image source="figures/AppExtGraphics/IntroPolar-51"></image>
         </p>
       </answer>
     </exercise>
@@ -1121,7 +1121,7 @@
         </p>
 
         <p>
-          <img src="figures/AppExtGraphics/IntroPolar-52"/>
+          <image source="figures/AppExtGraphics/IntroPolar-52"></image>
         </p>
       </answer>
     </exercise>
@@ -1141,7 +1141,7 @@
         </p>
 
         <p>
-          <img src="figures/AppExtGraphics/IntroPolar-53"/>
+          <image source="figures/AppExtGraphics/IntroPolar-53"></image>
         </p>
       </answer>
     </exercise>
@@ -1161,7 +1161,7 @@
         </p>
 
         <p>
-          <img src="figures/AppExtGraphics/IntroPolar-54"/>
+          <image source="figures/AppExtGraphics/IntroPolar-54"></image>
         </p>
       </answer>
     </exercise>
@@ -1181,7 +1181,7 @@
         </p>
 
         <p>
-          <img src="figures/AppExtGraphics/IntroPolar-55"/>
+          <image source="figures/AppExtGraphics/IntroPolar-55"></image>
         </p>
       </answer>
     </exercise>
@@ -1201,7 +1201,7 @@
         </p>
 
         <p>
-          <img src="figures/AppExtGraphics/IntroPolar-56"/>
+          <image source="figures/AppExtGraphics/IntroPolar-56"></image>
         </p>
       </answer>
     </exercise>

--- a/ptx/IntroRational.ptx
+++ b/ptx/IntroRational.ptx
@@ -208,7 +208,7 @@
 
     <figure xml:id="fig_ratgr1">
       <caption>The graph of <m>f(x) = \dfrac{2x-1}{x+1}</m></caption>
-      <img src="figures/RationalsGraphics/Rationals01"/>
+      <image source="figures/RationalsGraphics/Rationals01"></image>
     </figure>
 
     <figure xml:id="fig_rattab1">
@@ -417,7 +417,7 @@
     </aside>
     <figure xml:id="fig_ratgr3">
       <caption>The graph <m>y=h(x)</m> showing asymptotes and the <q>hole</q></caption>
-      <img src="figures/RationalsGraphics/IntroRational-1"/>
+      <image source="figures/RationalsGraphics/IntroRational-1"></image>
     </figure>
 
     <p>
@@ -533,7 +533,7 @@
                 as <m>x \rightarrow \sqrt{3}^{\, -}</m>,
                 <m>f(x) \rightarrow -\infty</m>,
                 and finally as <m>x\rightarrow \sqrt{3}^{\, +}</m>,
-                <m>f(x) \rightarrow \infty</m>. <figure xml:id="fig_ratgr4"> <caption>The graph <m>y=f(x)</m> in <xref ref="vavsholeexample">Example</xref></caption> <img src="figures/RationalsGraphics/Rationals02"/> </figure>
+                <m>f(x) \rightarrow \infty</m>. <figure xml:id="fig_ratgr4"> <caption>The graph <m>y=f(x)</m> in <xref ref="vavsholeexample">Example</xref></caption> <image source="figures/RationalsGraphics/Rationals02"></image> </figure>
               </p>
             </li>
 
@@ -559,7 +559,7 @@
                 as <m>x \rightarrow 3^{-}</m>,
                 <m>g(x) \rightarrow \frac{5}{6}^{-}</m>,
                 and as <m>x \rightarrow 3^{+}</m>,
-                <m>g(x) \rightarrow \frac{5}{6}^{+}</m>. <figure xml:id="fig_ratgr5"> <caption>The graph <m>y=g(x)</m> in <xref ref="vavsholeexample">Example</xref></caption> <img src="figures/RationalsGraphics/Rationals03"/> </figure>
+                <m>g(x) \rightarrow \frac{5}{6}^{+}</m>. <figure xml:id="fig_ratgr5"> <caption>The graph <m>y=g(x)</m> in <xref ref="vavsholeexample">Example</xref></caption> <image source="figures/RationalsGraphics/Rationals03"></image> </figure>
               </p>
             </li>
 
@@ -569,7 +569,7 @@
                 since <m>x^2+9 = 0</m> has no real solutions.
                 Accordingly,
                 the graph of <m>y=h(x)</m> is devoid of both vertical asymptotes and holes,
-                as see in <xref ref="fig_ratgr6">Figure</xref>. <figure xml:id="fig_ratgr6"> <caption>The graph <m>y=g(x)</m> in <xref ref="vavsholeexample">Example</xref></caption> <img src="figures/RationalsGraphics/Rationals04"/> </figure>
+                as see in <xref ref="fig_ratgr6">Figure</xref>. <figure xml:id="fig_ratgr6"> <caption>The graph <m>y=g(x)</m> in <xref ref="vavsholeexample">Example</xref></caption> <image source="figures/RationalsGraphics/Rationals04"></image> </figure>
               </p>
             </li>
 
@@ -584,7 +584,7 @@
                 bears this out, and, moreover,
                 we see that as <m>x\rightarrow -2^{-}</m>,
                 <m>r(x) \rightarrow \infty</m> and as <m>x \rightarrow -2^{+}</m>,
-                <m>r(x) \rightarrow -\infty</m>. <figure xml:id="fig_ratgr7"> <caption>The graph <m>y=r(x)</m> in <xref ref="vavsholeexample">Example</xref></caption> <img src="figures/RationalsGraphics/Rationals05"/> </figure>
+                <m>r(x) \rightarrow -\infty</m>. <figure xml:id="fig_ratgr7"> <caption>The graph <m>y=r(x)</m> in <xref ref="vavsholeexample">Example</xref></caption> <image source="figures/RationalsGraphics/Rationals05"></image> </figure>
               </p>
             </li>
           </ol>
@@ -663,7 +663,7 @@
                 To determine the behaviour of <m>P</m> as <m>t \rightarrow 5^{-}</m>,
                 we make the table in <xref ref="fig_rattab4">Figure</xref>. <table xml:id="fig_rattab4"> <caption>The behaviour of <m>P</m> as
                 <m>t\to 5^-</m></caption> <tabular> <row bottom="minor"> <cell></cell> <cell></cell> </row> <row> <cell><m>t</m></cell> <cell><m>P(t)</m></cell> </row> <row bottom="minor"> <cell></cell> <cell></cell> </row> <row> <cell>4.9</cell> <cell>10000</cell> </row> <row bottom="minor"> <cell></cell> <cell></cell> </row> <row> <cell>4.99</cell> <cell>1000000</cell> </row> <row bottom="minor"> <cell></cell> <cell></cell> </row> <row> <cell>4.999</cell> <cell>100000000</cell> </row> <row bottom="minor"> <cell></cell> <cell></cell> </row> <row> <cell>4.9999</cell> <cell>10000000000</cell> </row> <row bottom="minor"> <cell></cell> <cell></cell> </row> </tabular> </table> <figure xml:id="fig_doomsday"> <caption>The graph of <m>P(t)</m>,
-                for <m>0\leq t\lt 5</m></caption> <img src="figures/RationalsGraphics/Doomsday"/> </figure> In other words,
+                for <m>0\leq t\lt 5</m></caption> <image source="figures/RationalsGraphics/Doomsday"></image> </figure> In other words,
                 as <m>t \rightarrow 5^{-}</m>,
                 <m>P(t) \rightarrow \infty</m>.
                 Graphically,
@@ -858,7 +858,7 @@
                 We see from the calculator's graph that as <m>x \rightarrow -\infty</m>,
                 <m>h(x) \rightarrow -3^{+}</m>,
                 and as <m>x \rightarrow \infty</m>,
-                <m>h(x) \rightarrow -3^{-}</m>. <figure xml:id="fig_ratgr8"> <caption>Graphs of the three functions in <xref ref="haexample">Example</xref></caption> <sidebyside> <figure> <caption><m>y=f(x)</m></caption> <img src="figures/RationalsGraphics/Rationals06"/> </figure> <figure> <m>y=g(x)</m> </figure> <figure> <caption><m>y=h(x)</m></caption> <img src="figures/RationalsGraphics/Rationals08"/> </figure> </sidebyside> </figure>
+                <m>h(x) \rightarrow -3^{-}</m>. <figure xml:id="fig_ratgr8"> <caption>Graphs of the three functions in <xref ref="haexample">Example</xref></caption> <sidebyside> <figure> <caption><m>y=f(x)</m></caption> <image source="figures/RationalsGraphics/Rationals06"></image> </figure> <figure> <m>y=g(x)</m> </figure> <figure> <caption><m>y=h(x)</m></caption> <image source="figures/RationalsGraphics/Rationals08"></image> </figure> </sidebyside> </figure>
               </p>
             </li>
           </ol>
@@ -974,7 +974,7 @@
 
 
 
-      <img src="figures/RationalsGraphics/SA01"/>
+      <image source="figures/RationalsGraphics/SA01"></image>
     </figure>
 
     <figure xml:id="fig_slantas2">
@@ -1141,7 +1141,7 @@
 
                 <figure xml:id="fig_ratgr9">
                   <caption>The graph <m>y=f(x)</m> in <xref ref="saexample">Example</xref></caption>
-                  <img src="figures/RationalsGraphics/SAEX01"/>
+                  <image source="figures/RationalsGraphics/SAEX01"></image>
                 </figure>
 
                 <aside>
@@ -1175,7 +1175,7 @@
 
                 <figure xml:id="fig_ratgr10">
                   <caption>The graph <m>y=g(x)</m> in <xref ref="saexample">Example</xref></caption>
-                  <img src="figures/RationalsGraphics/SAEX02"/>
+                  <image source="figures/RationalsGraphics/SAEX02"></image>
                 </figure>
 
                 <aside>
@@ -1205,7 +1205,7 @@
                 the graph of <m>y=h(x)</m> approaches the asymptote from below,
                 and as <m>x \rightarrow \infty</m>,
                 the graph of <m>y=h(x)</m> approaches the asymptote from above:
-                see <xref ref="fig_ratgr11">Figure</xref>. <figure xml:id="fig_ratgr11"> <caption>The graph <m>y=h(x)</m> in <xref ref="saexample">Example</xref></caption> <img src="figures/RationalsGraphics/SAEX03"/> </figure>
+                see <xref ref="fig_ratgr11">Figure</xref>. <figure xml:id="fig_ratgr11"> <caption>The graph <m>y=h(x)</m> in <xref ref="saexample">Example</xref></caption> <image source="figures/RationalsGraphics/SAEX03"></image> </figure>
               </p>
             </li>
           </ol>

--- a/ptx/IntrotoFunctions.ptx
+++ b/ptx/IntrotoFunctions.ptx
@@ -71,12 +71,12 @@
     </aside>
     <figure xml:id="fig_relfunct1">
       <caption>The graph of <m>R_{1}</m></caption>
-      <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-1"/>
+      <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-1"></image>
     </figure>
 
     <figure xml:id="fig_relfunct2">
       <caption>The graph of <m>R_{2}</m></caption>
-      <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-2"/>
+      <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-2"></image>
     </figure>
 
     <p>
@@ -113,8 +113,8 @@
         </p>
         <tabular>
           <row>
-            <cell><img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-3"/></cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-4"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-3"></image></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-4"></image></cell>
           </row>
           <row>
             <cell>The graph of <m>R</m></cell>
@@ -152,8 +152,8 @@
         </p>
         <tabular>
           <row>
-            <cell><img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-5"/></cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-6"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-5"></image></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-6"></image></cell>
           </row>
           <row>
             <cell>The graph of <m>S_{1}</m></cell>
@@ -183,7 +183,7 @@
 
     <figure xml:id="fig_vlteg2">
       <caption><m>S_{1}</m> and the line <m>x=1</m></caption>
-      <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-7"/>
+      <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-7"></image>
     </figure>
 
     <p>
@@ -220,7 +220,7 @@
 
     <figure xml:id="fig_domaineg">
       <caption>The graph of <m>G</m> for <xref ref="firstdomainexample">Example</xref></caption>
-      <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-8"/>
+      <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-8"></image>
     </figure>
 
     <p>
@@ -259,12 +259,12 @@
 
         <figure xml:id="fig_domainegprojx">
           <caption>Projecting the graph onto the <m>x</m>-axis  in <xref ref="firstdomainexample">Example</xref></caption>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-9"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-9"></image>
         </figure>
 
         <figure xml:id="fig_domainegdom">
           <caption>The domain of <m>G</m> in <xref ref="firstdomainexample">Example</xref></caption>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-10"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-10"></image>
         </figure>
 
         <p>
@@ -387,12 +387,12 @@
 
     <figure xml:id="fig_domainegprojy">
       <caption>Projecting the graph onto the <m>y</m>-axis in <xref ref="firstdomainexample">Example</xref></caption>
-      <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-11"/>
+      <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-11"></image>
     </figure>
 
     <figure xml:id="fig_domainegran">
       <caption>The range of <m>G</m> in <xref ref="firstdomainexample">Example</xref></caption>
-      <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-12"/>
+      <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-12"></image>
     </figure>
   </introduction>
 
@@ -624,7 +624,7 @@
     <exercise>
       <statement>
         <sidebyside>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-13"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-13"></image>
         </sidebyside>
       </statement>
       <answer>
@@ -646,7 +646,7 @@
     <exercise>
       <statement>
         <sidebyside>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-14"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-14"></image>
         </sidebyside>
       </statement>
       <answer>
@@ -658,7 +658,7 @@
     <exercise>
       <statement>
         <sidebyside>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-15"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-15"></image>
         </sidebyside>
       </statement>
       <answer>
@@ -678,7 +678,7 @@
     <exercise>
       <statement>
         <sidebyside>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-16"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-16"></image>
         </sidebyside>
       </statement>
       <answer>
@@ -690,7 +690,7 @@
     <exercise>
       <statement>
         <sidebyside>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-17"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-17"></image>
         </sidebyside>
       </statement>
       <answer>
@@ -710,7 +710,7 @@
     <exercise>
       <statement>
         <sidebyside>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-18"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-18"></image>
         </sidebyside>
       </statement>
       <answer>
@@ -730,7 +730,7 @@
     <exercise>
       <statement>
         <sidebyside>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-19"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-19"></image>
         </sidebyside>
       </statement>
       <answer>
@@ -742,7 +742,7 @@
     <exercise>
       <statement>
         <sidebyside>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-20"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-20"></image>
         </sidebyside>
       </statement>
       <answer>
@@ -762,7 +762,7 @@
     <exercise>
       <statement>
         <sidebyside>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-21"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-21"></image>
         </sidebyside>
       </statement>
       <answer>
@@ -782,7 +782,7 @@
     <exercise>
       <statement>
         <sidebyside>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-22"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-22"></image>
         </sidebyside>
       </statement>
       <answer>
@@ -794,7 +794,7 @@
     <exercise>
       <statement>
         <sidebyside>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-23"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-23"></image>
         </sidebyside>
       </statement>
       <answer>
@@ -814,7 +814,7 @@
     <exercise>
       <statement>
         <sidebyside>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-24"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-24"></image>
         </sidebyside>
       </statement>
       <answer>
@@ -834,7 +834,7 @@
     <exercise>
       <statement>
         <sidebyside>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-25"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-25"></image>
         </sidebyside>
       </statement>
       <answer>
@@ -854,7 +854,7 @@
     <exercise>
       <statement>
         <sidebyside>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-26"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-26"></image>
         </sidebyside>
       </statement>
       <answer>
@@ -874,7 +874,7 @@
     <exercise>
       <statement>
         <sidebyside>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-27"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-27"></image>
         </sidebyside>
       </statement>
       <answer>
@@ -894,7 +894,7 @@
     <exercise>
       <statement>
         <sidebyside>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-28"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-28"></image>
         </sidebyside>
       </statement>
       <answer>
@@ -914,7 +914,7 @@
     <exercise>
       <statement>
         <sidebyside>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-29"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-29"></image>
         </sidebyside>
       </statement>
       <answer>
@@ -934,7 +934,7 @@
     <exercise>
       <statement>
         <sidebyside>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-30"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-30"></image>
         </sidebyside>
       </statement>
       <answer>
@@ -954,7 +954,7 @@
     <exercise>
       <statement>
         <sidebyside>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-31"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-31"></image>
         </sidebyside>
       </statement>
       <answer>
@@ -966,7 +966,7 @@
     <exercise>
       <statement>
         <sidebyside>
-          <img src="figures/RelationsandFunctionsGraphics/IntrotoFunctions-32"/>
+          <image source="figures/RelationsandFunctionsGraphics/IntrotoFunctions-32"></image>
         </sidebyside>
       </statement>
       <answer>

--- a/ptx/InverseFunctions.ptx
+++ b/ptx/InverseFunctions.ptx
@@ -92,7 +92,7 @@
 
     <figure xml:id="fig_inverse1">
       <caption>The relationship between a function and its inverse</caption>
-      <img src="figures/FurtherGraphics/InverseFunctions-1"/>
+      <image source="figures/FurtherGraphics/InverseFunctions-1"></image>
     </figure>
 
     <p>
@@ -184,7 +184,7 @@
 
     <figure xml:id="fig_inverse2">
       <caption>Reflecting <m>y=f(x)</m> across <m>y=x</m> to obtain <m>y=g(x)</m></caption>
-      <img src="figures/FurtherGraphics/InverseFunctions-2"/>
+      <image source="figures/FurtherGraphics/InverseFunctions-2"></image>
     </figure>
 
     <p>
@@ -283,7 +283,7 @@
 
     <figure xml:id="fig_inverse3">
       <caption>The function <m>f(x)=x^2</m> is not invertible</caption>
-      <img src="figures/FurtherGraphics/InverseFunctions-3"/>
+      <image source="figures/FurtherGraphics/InverseFunctions-3"></image>
     </figure>
 
     <p>
@@ -303,7 +303,7 @@
       <caption>Reflecting <m>y=x^2</m> across the line <m>y=x</m> does not produce a function</caption>
       <tabular>
         <row>
-          <cell><img src="figures/FurtherGraphics/InverseFunctions-4"/></cell>
+          <cell><image source="figures/FurtherGraphics/InverseFunctions-4"></image></cell>
         </row>
         <row>
           <cell>(a) <m>y=f(x)=x^2</m></cell>
@@ -312,7 +312,7 @@
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/FurtherGraphics/InverseFunctions-5"/></cell>
+          <cell><image source="figures/FurtherGraphics/InverseFunctions-5"></image></cell>
         </row>
         <row>
           <cell>(b) <m>y=f^{-1}(x)</m>?</cell>
@@ -484,7 +484,7 @@
                   We have that <m>f</m> is a non-constant linear function,
                   which means its graph is a non-horizontal line.
                   Thus the graph of <m>f</m> passes the Horizontal Line Test:
-                  see <xref ref="fig_inverse5">Figure</xref>. <figure xml:id="fig_inverse5"> <caption>The function <m>f</m> is one-to-one</caption> <img src="figures/FurtherGraphics/InverseFunctions-6"/> </figure>
+                  see <xref ref="fig_inverse5">Figure</xref>. <figure xml:id="fig_inverse5"> <caption>The function <m>f</m> is one-to-one</caption> <image source="figures/FurtherGraphics/InverseFunctions-6"></image> </figure>
                 </p>
               </li>
             </ol></li>
@@ -523,7 +523,7 @@
 
             <figure xml:id="fig_inverse6">
               <caption>The function <m>g</m> is one-to-one</caption>
-              <img src="figures/FurtherGraphics/InverseFunctions-7"/>
+              <image source="figures/FurtherGraphics/InverseFunctions-7"></image>
             </figure>
 
           </li>
@@ -577,7 +577,7 @@
 
             <figure xml:id="fig_inverse7">
               <caption>The function <m>h</m> is not one-to-one</caption>
-              <img src="figures/FurtherGraphics/InverseFunctions-8"/>
+              <image source="figures/FurtherGraphics/InverseFunctions-8"></image>
             </figure>
 
           </li>
@@ -608,7 +608,7 @@
 
         <figure xml:id="fig_inverse8">
           <caption>The function <m>F</m> is not one-to-one</caption>
-          <img src="figures/FurtherGraphics/InverseFunctions-9"/>
+          <image source="figures/FurtherGraphics/InverseFunctions-9"></image>
         </figure>
       </solution>
     </example>
@@ -736,7 +736,7 @@
 
                 <figure xml:id="fig_inverse9">
                   <caption>The graphs of <m>f</m> and <m>f^{-1}</m> from <xref ref="ex_inverse1">Example</xref></caption>
-                  <img src="figures/FurtherGraphics/InverseFunctions-10"/>
+                  <image source="figures/FurtherGraphics/InverseFunctions-10"></image>
                 </figure>
 
               </p>
@@ -790,7 +790,7 @@
 
                 <figure xml:id="fig_inverse10">
                   <caption>The graphs of <m>g</m> and <m>g^{-1}</m> from <xref ref="ex_inverse1">Example</xref></caption>
-                  <img src="figures/FurtherGraphics/InverseFunctions-11"/>
+                  <image source="figures/FurtherGraphics/InverseFunctions-11"></image>
                 </figure>
 
               </p>
@@ -814,7 +814,7 @@
       <caption>Restricting the domain of <m>f(x)=x^2</m></caption>
       <tabular>
         <row>
-          <cell><img src="figures/FurtherGraphics/InverseFunctions-12"/></cell>
+          <cell><image source="figures/FurtherGraphics/InverseFunctions-12"></image></cell>
         </row>
         <row>
           <cell>(a) <m>y=f(x)=x^2</m></cell>
@@ -823,7 +823,7 @@
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/FurtherGraphics/InverseFunctions-13"/></cell>
+          <cell><image source="figures/FurtherGraphics/InverseFunctions-13"></image></cell>
         </row>
         <row>
           <cell>(b) <m>y=g(x)=x^2, x\geq 0</m></cell>
@@ -897,7 +897,7 @@
 
                 <figure xml:id="fig_inverse12">
                   <caption>The restricted function <m>g</m> and its inverse</caption>
-                  <img src="figures/FurtherGraphics/InverseFunctions-14"/>
+                  <image source="figures/FurtherGraphics/InverseFunctions-14"></image>
                 </figure>
 
                 We now use our algorithm to find <m>j^{-1}(x)</m>. (Here,
@@ -925,7 +925,7 @@
                 <figure xml:id="fig_inverse13">
                   <caption><m>y=x^2-2x+4</m>,
                 for <m>x\leq 1</m></caption>
-                  <img src="figures/FurtherGraphics/InverseFunctions-15"/>
+                  <image source="figures/FurtherGraphics/InverseFunctions-15"></image>
                 </figure>
 
                 We have <m>j^{-1}(x) = 1 - \sqrt{x-3}</m>.
@@ -957,7 +957,7 @@
 
                 <figure xml:id="fig_inverse14">
                   <caption>The graphs of <m>j</m> and <m>j^{-1}</m> from <xref ref="inverserestrictionex">Example</xref></caption>
-                  <img src="figures/FurtherGraphics/InverseFunctions-16"/>
+                  <image source="figures/FurtherGraphics/InverseFunctions-16"></image>
                 </figure>
 
               </p>
@@ -971,7 +971,7 @@
 
                 <figure xml:id="fig_inverse15">
                   <caption><m>y=\sqrt{x+2}-1</m></caption>
-                  <img src="figures/FurtherGraphics/InverseFunctions-17"/>
+                  <image source="figures/FurtherGraphics/InverseFunctions-17"></image>
                 </figure>
 
                 We now try to find <m>k^{-1}</m>.
@@ -1041,7 +1041,7 @@
 
                 <figure xml:id="fig_inverse16">
                   <caption>The graphs of <m>k</m> and <m>k^{-1}</m> from <xref ref="inverserestrictionex">Example</xref></caption>
-                  <img src="figures/FurtherGraphics/InverseFunctions-18"/>
+                  <image source="figures/FurtherGraphics/InverseFunctions-18"></image>
                 </figure>
 
               </p>

--- a/ptx/LawofCosines.ptx
+++ b/ptx/LawofCosines.ptx
@@ -223,7 +223,7 @@
               Using this,
               we get <m>\gamma = \arccos\left(\frac{5}{7}\right)</m> radians
               <m>\approx 44.42^{\circ}</m> and <m>\alpha = \arccos\left(\frac{29}{35}\right)</m> radians
-              <m>\approx 34.05^{\circ}</m>. <!-- <caption>Triangle for Example \ref{locex}.\ref{locsss}</caption> --> <sidebyside> <img src="figures/AppExtGraphics/LawofCosines-3"/> </sidebyside>
+              <m>\approx 34.05^{\circ}</m>. <!-- <caption>Triangle for Example \ref{locex}.\ref{locsss}</caption> --> <sidebyside> <image source="figures/AppExtGraphics/LawofCosines-3"></image> </sidebyside>
             </p>
             </li>
           </ol>
@@ -258,7 +258,7 @@
 
         <figure xml:id="fig_cosines4">
           <caption>The pond in <xref ref="locapplication">Example</xref></caption>
-          <img src="figures/AppExtGraphics/LawofCosines-4"/>
+          <image source="figures/AppExtGraphics/LawofCosines-4"></image>
         </figure>
       </statement>
       <solution>
@@ -742,7 +742,7 @@
         </p>
 
         <p>
-          <img src="figures/AppExtGraphics/LawofCosines-5"/>
+          <image source="figures/AppExtGraphics/LawofCosines-5"></image>
         </p>
       </statement>
       <answer>

--- a/ptx/LawofSines.ptx
+++ b/ptx/LawofSines.ptx
@@ -35,7 +35,7 @@
 
         <figure xml:id="fig_sines1">
           <caption>The triangle in <xref ref="righttrianglereviewex">Example</xref></caption>
-          <img src="figures/AppExtGraphics/LawofSines-1"/>
+          <image source="figures/AppExtGraphics/LawofSines-1"></image>
         </figure>
 
         <p>
@@ -281,7 +281,7 @@
                 but that becomes unnecessarily messy for the discussion at hand.
                 Thus <q>exact</q>
                 here means <m>\frac{7\sin\left(15^{\circ}\right)}{\sin\left(120^{\circ}\right)}</m>. <figure xml:id="fig_sineseg1"> <caption>Triangle for <xref ref="losex">Example</xref>
-                <xref ref="losaas">number</xref></caption> <img src="figures/AppExtGraphics/LawofSines-8"/> </figure>
+                <xref ref="losaas">number</xref></caption> <image source="figures/AppExtGraphics/LawofSines-8"></image> </figure>
               </p>
             </li>
 
@@ -299,7 +299,7 @@
                 To find <m>b</m> we use the angle-side pair
                 <m>(\gamma,c)</m> which yields <m>\frac{b}{\sin\left(30^{\circ}\right)} = \frac{5.25}{\sin\left(65^{\circ}\right)}</m> hence
                 <m>b = \frac{5.25\sin\left(30^{\circ}\right)}{\sin\left(65^{\circ}\right)} \approx 2.90</m> units. <figure xml:id="fig_sineseg2"> <caption>Triangle for <xref ref="losex">Example</xref>
-                <xref ref="losasa">number</xref></caption> <img src="figures/AppExtGraphics/LawofSines-9"/> </figure>
+                <xref ref="losasa">number</xref></caption> <image source="figures/AppExtGraphics/LawofSines-9"></image> </figure>
               </p>
             </li>
 
@@ -314,7 +314,7 @@
                 we see that side <m>a</m> is just too short to make a triangle.
                 The next three examples keep the same values for the measure of <m>\alpha</m> and the length of <m>c</m> while varying the length of <m>a</m>.
                 We will discuss this case in more detail after we see what happens in those examples. <figure xml:id="fig_sineseg3"> <caption>Triangle for <xref ref="losex">Example</xref>
-                <xref ref="losnotriangleex">number</xref></caption> <img src="figures/AppExtGraphics/LawofSines-10"/> </figure>
+                <xref ref="losnotriangleex">number</xref></caption> <image source="figures/AppExtGraphics/LawofSines-10"></image> </figure>
               </p>
             </li>
 
@@ -335,7 +335,7 @@
                 We find <m>b = \frac{2 \sin\left(60^{\circ}\right)}{\sin\left(30^{\circ}\right)} = 2 \sqrt{3} \approx 3.46</m> units.
                 In this case,
                 the side <m>a</m> is precisely long enough to form a unique right triangle. <figure xml:id="fig_sineseg4"> <caption>Triangle for <xref ref="losex">Example</xref>
-                <xref ref="losrighttriangleex">number</xref></caption> <img src="figures/AppExtGraphics/LawofSines-11"/> </figure>
+                <xref ref="losrighttriangleex">number</xref></caption> <image source="figures/AppExtGraphics/LawofSines-11"></image> </figure>
               </p>
             </li>
 
@@ -378,7 +378,7 @@
               we repeat the exact same steps and find <m>\beta \approx 11.81^{\circ}</m> and
               <m>b \approx 1.23</m> units. (An exact answer for <m>\beta</m> in this case is <m>\beta = \arcsin\left(\frac{2}{3}\right) - \frac{\pi}{6}</m> radians
               <m>\approx 11.81^{\circ}</m>.) Both triangles are drawn in <xref ref="fig_sineseg5">Figure</xref>
-              below. <!-- <caption>Triangle for Example \ref{losex} number \ref{lostwotriangleex}</caption> --> <sidebyside> <tabular> <row> <cell><img src="figures/AppExtGraphics/LawofSines-12"/></cell> <cell><img src="figures/AppExtGraphics/LawofSines-13"/></cell> </row> </tabular> </sidebyside>
+              below. <!-- <caption>Triangle for Example \ref{losex} number \ref{lostwotriangleex}</caption> --> <sidebyside> <tabular> <row> <cell><image source="figures/AppExtGraphics/LawofSines-12"></image></cell> <cell><image source="figures/AppExtGraphics/LawofSines-13"></image></cell> </row> </tabular> </sidebyside>
             </p>
             </li>
 
@@ -396,7 +396,7 @@
                 So <m>\beta = 180^{\circ} - 30^{\circ} - 30^{\circ} = 120^{\circ}</m> and,
                 using the Law of Sines one last time,
                 <m>b = \frac{4\sin\left(120^{\circ}\right)}{\sin\left(30^{\circ}\right)} = 4\sqrt{3} \approx 6.93</m> units. <figure xml:id="fig_sineseg6"> <caption>Triangle for <xref ref="losex">Example</xref>
-                <xref ref="losonetriangleex">number</xref></caption> <img src="figures/AppExtGraphics/LawofSines-14"/> </figure>
+                <xref ref="losonetriangleex">number</xref></caption> <image source="figures/AppExtGraphics/LawofSines-14"></image> </figure>
               </p>
             </li>
           </ol>
@@ -500,8 +500,8 @@
     <sidebyside>
       <tabular>
         <row>
-          <cell><img src="figures/AppExtGraphics/LawofSines-15"/></cell>
-          <cell><img src="figures/AppExtGraphics/LawofSines-16"/></cell>
+          <cell><image source="figures/AppExtGraphics/LawofSines-15"></image></cell>
+          <cell><image source="figures/AppExtGraphics/LawofSines-16"></image></cell>
         </row>
         <row>
           <cell><m>a\lt h</m>, no triangle</cell>
@@ -553,8 +553,8 @@
     <sidebyside>
       <tabular>
         <row>
-          <cell><img src="figures/AppExtGraphics/LawofSines-17"/></cell>
-          <cell><img src="figures/AppExtGraphics/LawofSines-18"/></cell>
+          <cell><image source="figures/AppExtGraphics/LawofSines-17"></image></cell>
+          <cell><image source="figures/AppExtGraphics/LawofSines-18"></image></cell>
         </row>
         <row>
           <cell><m>h \lt  a \lt  c</m>, two triangles</cell>
@@ -587,13 +587,13 @@
           <caption>Diagrams for <xref ref="losapplication">Example</xref></caption>
           <tabular>
             <row>
-              <cell><img src="figures/AppExtGraphics/LawofSines-19"/></cell>
+              <cell><image source="figures/AppExtGraphics/LawofSines-19"></image></cell>
             </row>
             <row>
               <cell></cell>
             </row>
             <row>
-              <cell><img src="figures/AppExtGraphics/LawofSines-20"/></cell>
+              <cell><image source="figures/AppExtGraphics/LawofSines-20"></image></cell>
             </row>
           </tabular>
         </table>
@@ -1087,7 +1087,7 @@
     </p>
 
     <p>
-      <img src="figures/AppExtGraphics/LawofSines-21"/>
+      <image source="figures/AppExtGraphics/LawofSines-21"></image>
     </p>
 
     <p>

--- a/ptx/LinearFunctions.ptx
+++ b/ptx/LinearFunctions.ptx
@@ -13,7 +13,7 @@
 
     <figure xml:id="fig_linfun1">
       <caption>The line between two points <m>P</m> and <m>Q</m></caption>
-      <img src="figures/LinearQuadraticGraphics/LinearFunctions-1"/>
+      <image source="figures/LinearQuadraticGraphics/LinearFunctions-1"></image>
     </figure>
 
     <p>
@@ -72,11 +72,11 @@
 
             <li>
               <p>
-                <m>P(-1,2)</m>, <m>Q(3,4)</m> \setcounter{HW}{\value{enumi}}
+                <m>P(-1,2)</m>, <m>Q(3,4)</m>
               </p>
             </li>
 
-            \setcounter{enumi}{\value{HW}}
+            
 
             <li>
               <p>
@@ -86,11 +86,11 @@
 
             <li>
               <p>
-                <m>P(-3,2)</m>, <m>Q(4,2)</m> \setcounter{HW}{\value{enumi}}
+                <m>P(-3,2)</m>, <m>Q(4,2)</m>
               </p>
             </li>
 
-            \setcounter{enumi}{\value{HW}}
+            
 
             <li>
               <p>
@@ -115,28 +115,28 @@
             <li>
               <p>
                 <tabular> {m{2.5in}m{2.5in}} <m>m = \dfrac{4 - 0}{2 - 0} = \dfrac{4}{2} = 2</m> &amp;
-                <img src="figures/LinearQuadraticGraphics/LinearFunctions-2"/> </tabular>
+                <image source="figures/LinearQuadraticGraphics/LinearFunctions-2"></image> </tabular>
               </p>
             </li>
 
             <li>
               <p>
                 <tabular> {m{2.5in}m{2.5in}} <m>m = \dfrac{4 - 2}{3 - (-1)} = \dfrac{2}{4} = \dfrac{1}{2}</m> &amp;
-                <img src="figures/LinearQuadraticGraphics/LinearFunctions-3"/> </tabular>
+                <image source="figures/LinearQuadraticGraphics/LinearFunctions-3"></image> </tabular>
               </p>
             </li>
 
             <li>
               <p>
                 <tabular> {m{2.5in}m{2.5in}} <m>m = \dfrac{-3 - 3}{2 - (-2)} = \dfrac{-6}{4} = -\dfrac{3}{2}</m> &amp;
-                <img src="figures/LinearQuadraticGraphics/LinearFunctions-4"/> </tabular>
+                <image source="figures/LinearQuadraticGraphics/LinearFunctions-4"></image> </tabular>
               </p>
             </li>
 
             <li>
               <p>
                 <tabular> {m{2.5in}m{2.5in}} <m>m = \dfrac{2 - 2}{4 - (-3)} = \dfrac{0}{7} = 0</m> &amp;
-                <img src="figures/LinearQuadraticGraphics/LinearFunctions-5"/> </tabular>
+                <image source="figures/LinearQuadraticGraphics/LinearFunctions-5"></image> </tabular>
               </p>
             </li>
 
@@ -144,14 +144,14 @@
               <p>
                 <tabular> {m{3in}m{2in}} <m>m = \dfrac{-1 - 3}{2 - 2} = \dfrac{-4}{0}</m>,
                 which is undefined &amp;
-                <img src="figures/LinearQuadraticGraphics/LinearFunctions-6"/> </tabular>
+                <image source="figures/LinearQuadraticGraphics/LinearFunctions-6"></image> </tabular>
               </p>
             </li>
 
             <li>
               <p>
                 <tabular> {m{3in}m{2in}} <m>m = \dfrac{-1 - 3}{2.1 - 2} = \dfrac{-4}{0.1}=-40</m> &amp;
-                <img src="figures/LinearQuadraticGraphics/LinearFunctions-7"/> </tabular>
+                <image source="figures/LinearQuadraticGraphics/LinearFunctions-7"></image> </tabular>
               </p>
             </li>
           </ol>
@@ -178,7 +178,7 @@
 
     <figure xml:id="fig_riserun">
       <caption>Slope as <q>rise over run</q></caption>
-      <img src="figures/LinearQuadraticGraphics/LinearFunctions-8"/>
+      <image source="figures/LinearQuadraticGraphics/LinearFunctions-8"></image>
     </figure>
 
     <p>
@@ -302,7 +302,7 @@
 
     <figure xml:id="fig_linfun2">
       <caption>Deriving the point-slope formula</caption>
-      <img src="figures/LinearQuadraticGraphics/LinearFunctions-9"/>
+      <image source="figures/LinearQuadraticGraphics/LinearFunctions-9"></image>
     </figure>
 
     <insight xml:id="pointslope">
@@ -471,7 +471,7 @@
               <p>
                 To graph <m>f(x) = 3</m>, we graph <m>y=3</m>.
                 This is a horizontal line (<m>m=0</m>) through <m>(0,3)</m>:
-                see <xref ref="fig_linfun3">Figure</xref>. <figure xml:id="fig_linfun3"> <caption>The graph of <m>f(x)=3</m></caption> <img src="figures/LinearQuadraticGraphics/LinearFunctions-10"/> </figure>
+                see <xref ref="fig_linfun3">Figure</xref>. <figure xml:id="fig_linfun3"> <caption>The graph of <m>f(x)=3</m></caption> <image source="figures/LinearQuadraticGraphics/LinearFunctions-10"></image> </figure>
               </p>
             </li>
 
@@ -485,7 +485,7 @@
                 To get another point on the line,
                 we can plot <m>(1,f(1)) = (1,2)</m>.
                 Constructing the line through these points gives us <xref ref="fig_linfun4">Figure</xref>. <figure xml:id="fig_linfun4"> <caption>The graph of
-                <m>f(x)=3x-1</m></caption> <img src="figures/LinearQuadraticGraphics/LinearFunctions-11"/> </figure>
+                <m>f(x)=3x-1</m></caption> <image source="figures/LinearQuadraticGraphics/LinearFunctions-11"></image> </figure>
               </p>
             </li>
 
@@ -500,7 +500,7 @@
                 Plotting an additional point,
                 we can choose <m>(1,f(1))</m> to get <m>\left(1, \frac{1}{4}\right)</m>:
                 see <xref ref="fig_linfun5">Figure</xref>. <figure xml:id="fig_linfun5"> <caption>The graph of
-                <m>f(x)=\dfrac{3-2x}{4}</m></caption> <img src="figures/LinearQuadraticGraphics/LinearFunctions-12"/> </figure>
+                <m>f(x)=\dfrac{3-2x}{4}</m></caption> <image source="figures/LinearQuadraticGraphics/LinearFunctions-12"></image> </figure>
               </p>
             </li>
 
@@ -534,7 +534,7 @@
 
     <figure xml:id="fig_linfun6">
       <caption>The graph of <m>f(x)=\dfrac{x^2-4}{x-2}</m></caption>
-      <img src="figures/LinearQuadraticGraphics/LinearFunctions-13"/>
+      <image source="figures/LinearQuadraticGraphics/LinearFunctions-13"></image>
     </figure>
 
     <p>
@@ -860,7 +860,7 @@
 
     <figure xml:id="fig_avsecant">
       <caption>The graph of <m>y=f(x)</m> and its secant line through <m>(a,f(a))</m> and <m>(b,f(b))</m></caption>
-      <img src="figures/LinearQuadraticGraphics/LinearFunctions-14"/>
+      <image source="figures/LinearQuadraticGraphics/LinearFunctions-14"></image>
     </figure>
 
     <p>
@@ -1324,7 +1324,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/LinearFunctions-17"/>
+          <image source="figures/LinearQuadraticGraphics/LinearFunctions-17"></image>
         </p>
       </answer>
     </exercise>
@@ -1352,7 +1352,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/LinearFunctions-18"/>
+          <image source="figures/LinearQuadraticGraphics/LinearFunctions-18"></image>
         </p>
       </answer>
     </exercise>
@@ -1380,7 +1380,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/LinearFunctions-19"/>
+          <image source="figures/LinearQuadraticGraphics/LinearFunctions-19"></image>
         </p>
       </answer>
     </exercise>
@@ -1409,7 +1409,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/LinearFunctions-20"/>
+          <image source="figures/LinearQuadraticGraphics/LinearFunctions-20"></image>
         </p>
       </answer>
     </exercise>
@@ -1437,7 +1437,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/LinearFunctions-21"/>
+          <image source="figures/LinearQuadraticGraphics/LinearFunctions-21"></image>
         </p>
       </answer>
     </exercise>
@@ -1465,7 +1465,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/LinearFunctions-22"/>
+          <image source="figures/LinearQuadraticGraphics/LinearFunctions-22"></image>
         </p>
       </answer>
     </exercise>
@@ -1806,7 +1806,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/LinearFunctions-15"/>
+          <image source="figures/LinearQuadraticGraphics/LinearFunctions-15"></image>
         </p>
       </statement>
       <answer>
@@ -1835,7 +1835,7 @@
 
           <li>
             <p>
-              <m>~</m> <tabular> <row> <cell><img src="figures/LinearQuadraticGraphics/LinearFunctions-23"/></cell> </row> <row> <cell><m>y=D(d)</m></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/LinearQuadraticGraphics/LinearFunctions-24"/></cell> </row> <row> <cell><m>y=D(s)</m></cell> </row> </tabular>
+              <m>~</m> <tabular> <row> <cell><image source="figures/LinearQuadraticGraphics/LinearFunctions-23"></image></cell> </row> <row> <cell><m>y=D(d)</m></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/LinearQuadraticGraphics/LinearFunctions-24"></image></cell> </row> <row> <cell><m>y=D(s)</m></cell> </row> </tabular>
             </p>
           </li>
         </ol>
@@ -2274,7 +2274,7 @@
           We can also <q>move</q>
           the lines so that their point of intersection is the origin without messing things up,
           so we'll assume <m>b_{1} = b_{2} = 0</m>. (Take a moment with your classmates to discuss why this is okay.) Graphing the lines and plotting the points <m>O(0, 0)\;</m>,
-          <m>P(1, m_{1})\;</m> and <m>Q(1, m_{2})</m> gives us the following set up. <img src="figures/LinearQuadraticGraphics/LinearFunctions-16"/>
+          <m>P(1, m_{1})\;</m> and <m>Q(1, m_{2})</m> gives us the following set up. <image source="figures/LinearQuadraticGraphics/LinearFunctions-16"></image>
         </p>
 
         <p>

--- a/ptx/LogEquations.ptx
+++ b/ptx/LogEquations.ptx
@@ -72,11 +72,11 @@
 
             <li>
               <p>
-                <m>2 - \ln(x-3) = 1</m> \setcounter{HW}{\value{enumi}}
+                <m>2 - \ln(x-3) = 1</m>
               </p>
             </li>
 
-            \setcounter{enumi}{\value{HW}}
+            
 
             <li>
               <p>
@@ -86,11 +86,11 @@
 
             <li>
               <p>
-                <m>\log_{7}(1-2x) = 1 - \log_{7}(3-x)</m> \setcounter{HW}{\value{enumi}}
+                <m>\log_{7}(1-2x) = 1 - \log_{7}(3-x)</m>
               </p>
             </li>
 
-            \setcounter{enumi}{\value{HW}}
+            
 
             <li>
               <p>
@@ -123,7 +123,7 @@
                 which means <m>x=1</m> is not in the domain of the original equation,
                 and is not a solution.
                 Using GeoGebra to solve the equation graphically gives us <xref ref="fig_logeqn1">Figure</xref>. <figure xml:id="fig_logeqn1"> <caption>\color{red} <m>y=f(x)=\log_{117}(1-3x)</m> and {\color{blue}
-                <m>y=g(x)=\log_{117}(x^2-3)</m>}</caption> <img src="figures/ExpLogsGraphics/ExpLogs15"/> </figure>
+                <m>y=g(x)=\log_{117}(x^2-3)</m>}</caption> <image source="figures/ExpLogsGraphics/ExpLogs15"></image> </figure>
               </p>
             </li>
 
@@ -138,7 +138,7 @@
                 we see the graph of
           <m>f(x) = 2 - \ln(x-3)</m> intersects the graph of <m>g(x) = 1</m> at
                 <m>x = e+3 \approx 5.718</m>. <figure xml:id="fig_logeqn2"> <caption>\color{red} <m>y=f(x)=2-\ln(x-3)</m> and {\color{blue}
-                <m>y=g(x)=1</m>}</caption> <img src="figures/ExpLogsGraphics/ExpLogs16"/> </figure>
+                <m>y=g(x)=1</m>}</caption> <image source="figures/ExpLogsGraphics/ExpLogs16"></image> </figure>
               </p>
             </li>
 
@@ -155,7 +155,7 @@
                 at <m>x=-3</m> and <m>x=2</m>
                 (<xref ref="fig_logeqn3">Figure</xref>).
                 <figure xml:id="fig_logeqn3"> <caption>\color{red} <m>y=f(x)=\log_6(x+4)+\log_6(3-x)</m> and {\color{blue}
-                <m>y=g(x)=1</m>}</caption> <img src="figures/ExpLogsGraphics/ExpLogs17"/> </figure>
+                <m>y=g(x)=1</m>}</caption> <image source="figures/ExpLogsGraphics/ExpLogs17"></image> </figure>
               </p>
             </li>
 
@@ -174,7 +174,7 @@
                 see <xref ref="fig_logeqn4">Figure</xref>.
                 Checking <m>x=4</m> in the original equation produces <m>\log_{7}(-7) = 1 - \log_{7}(-1)</m>,
                 which is a clear domain violation. <figure xml:id="fig_logeqn4"> <caption>\color{red} <m>y=f(x)=\log_7(1-2x)</m> and {\color{blue}
-                <m>y=g(x)=1-\log_7(3-x)</m>}</caption> <img src="figures/ExpLogsGraphics/ExpLogs18"/> </figure>
+                <m>y=g(x)=1-\log_7(3-x)</m>}</caption> <image source="figures/ExpLogsGraphics/ExpLogs18"></image> </figure>
               </p>
             </li>
 
@@ -195,7 +195,7 @@
                 <figure xml:id="fig_logeqn5">
                   <caption>\color{red} <m>y=f(x)=\log_2(x+3)</m> 
                   and  {\color{blue} <m>y=g(x)=log_2(6-x)+3</m>}</caption>
-                  <img src="figures/ExpLogsGraphics/ExpLogs19"/>
+                  <image source="figures/ExpLogsGraphics/ExpLogs19"></image>
                 </figure>
 
               </p>
@@ -233,7 +233,7 @@
                 <figure xml:id="fig_logeqn6">
                   <caption>\color{red} <m>y=f(x)=1+2\log_4(x+1)</m> 
                   and {\color{blue} <m>y=g(x)=2\log_2(x)</m>}</caption>
-                  <img src="figures/ExpLogsGraphics/ExpLogs20"/>
+                  <image source="figures/ExpLogsGraphics/ExpLogs20"></image>
                 </figure>
 
               </p>
@@ -320,7 +320,7 @@
                 the graph of <m>f</m> is below the graph of <m>g</m> on the solution intervals,
                 and that the graphs intersect at <m>x=1</m>. <figure xml:id="fig_logineq1"> <caption>Solving
           <m>\dfrac{1}{\ln(x)+1}\leq 1</m></caption> <sidebyside> <figure> <caption>Sign diagram for
-          <m>r(x)=\dfrac{\ln(x)}{\ln(x)+1}</m></caption> <img src="figures/ExpLogsGraphics/LogEquations-1"/> </figure> <figure> <caption>and {\color{blue}
+          <m>r(x)=\dfrac{\ln(x)}{\ln(x)+1}</m></caption> <image source="figures/ExpLogsGraphics/LogEquations-1"></image> </figure> <figure> <caption>and {\color{blue}
                 <m>y=g(x)=1</m>}</caption> {\color{red}
                 <m>y=f(x)=\dfrac{1}{\ln(x)+1}</m>} </figure> </sidebyside> </figure>
               </p>
@@ -352,7 +352,7 @@
                 <m>f(x)= \left(\frac{\ln(x)}{\ln(2)}\right)^2</m> is below the graph of
                 <m>y = g(x) = \frac{2 \ln(x)}{\ln(2)} + 3</m> on the solution interval:
                 see <xref ref="fig_logineq2">Figure</xref>. <table xml:id="fig_logineq2"> <caption>Solving
-          <m>(\log_2(x))^2\lt 2\log_2(x)+3</m></caption> <tabular> <row> <cell><img src="figures/ExpLogsGraphics/LogEquations-2"/></cell> </row> <row> <cell>Sign diagram for</cell> </row> <row> <cell><m>r(x)=(\log_2(x))^2-2\log_2(x)-3</m></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/ExpLogsGraphics/ExpLogs22"/></cell> </row> <row> <cell>{\color{red}
+          <m>(\log_2(x))^2\lt 2\log_2(x)+3</m></caption> <tabular> <row> <cell><image source="figures/ExpLogsGraphics/LogEquations-2"></image></cell> </row> <row> <cell>Sign diagram for</cell> </row> <row> <cell><m>r(x)=(\log_2(x))^2-2\log_2(x)-3</m></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/ExpLogsGraphics/ExpLogs22"></image></cell> </row> <row> <cell>{\color{red}
           <m>y=f(x)=(\log_2(x))^2</m>} and</cell> </row> <row> <cell>{\color{blue}
                 <m>y=g(x)=2\log_2(x)+3</m>}</cell> </row> </tabular> </table>
               </p>
@@ -376,7 +376,7 @@
                 indicates the graph of <m>y= f(x) = x \log(x+1)</m> is above
                 <m>y=g(x) = x</m> on the solution intervals,
                 and the graphs intersect at <m>x=0</m> and <m>x=9</m>. <figure xml:id="fig_logineq3"> <caption>Solving <m>x\log(x+1)\geq x</m></caption> <sidebyside> <figure> <caption>Sign diagram for
-          <m>r(x)=x\log(x+1)-x</m></caption> <img src="figures/ExpLogsGraphics/LogEquations-3"/> </figure> <figure> <caption>and {\color{blue}
+          <m>r(x)=x\log(x+1)-x</m></caption> <image source="figures/ExpLogsGraphics/LogEquations-3"></image> </figure> <figure> <caption>and {\color{blue}
           <m>y=g(x)=x</m>}</caption> {\color{red}
                 <m>y=f(x)=x\log(x+1)</m>} </figure> </sidebyside> </figure>
               </p>
@@ -418,7 +418,7 @@
 
         <figure xml:id="fig_pHlog">
           <caption>The graphs of {\color{red} <m>y = f(x) = -\log(x)</m>}, {\color{green} <m>y = 7.8</m>} and {\color{orange} <m>y = 8.5</m>}</caption>
-          <img src="figures/ExpLogsGraphics/ExpLogs24"/>
+          <image source="figures/ExpLogsGraphics/ExpLogs24"></image>
         </figure>
       </solution>
     </example>
@@ -459,7 +459,7 @@
         <figure xml:id="fig_loginverse">
           <caption>\color{red} <m>y=f(x)=\dfrac{\log(x)}{1-\log(x)}</m>
           and {\color{blue} <m>y=g(x)=10^{\frac{x}{x+1}}</m>}</caption>
-          <img src="figures/ExpLogsGraphics/ExpLogs25"/>
+          <image source="figures/ExpLogsGraphics/ExpLogs25"></image>
         </figure>
       </solution>
     </example>

--- a/ptx/LogProperties.ptx
+++ b/ptx/LogProperties.ptx
@@ -413,11 +413,11 @@
 
             <li>
               <p>
-                <m>\log(x) + 2\log(y) - \log(z)</m> \setcounter{HW}{\value{enumi}}
+                <m>\log(x) + 2\log(y) - \log(z)</m>
               </p>
             </li>
 
-            \setcounter{enumi}{\value{HW}}
+            
 
             <li>
               <p>
@@ -650,7 +650,7 @@
                 and <m>g(x) = e^{x \ln(2)}</m> (in blue).
                 Their graphs are indistinguishable which provides evidence that they are the same function:
                 see <xref ref="fig_logprop1">Figure</xref>. <figure xml:id="fig_logprop1"> <caption><m>y=f(x)=2^x</m> and
-                <m>y=g(x)=e^{x\ln(2)}</m></caption> <img src="figures/ExpLogsGraphics/ExpLogs03"/> </figure>
+                <m>y=g(x)=e^{x\ln(2)}</m></caption> <image source="figures/ExpLogsGraphics/ExpLogs03"></image> </figure>
               </p>
             </li>
 
@@ -672,7 +672,7 @@
                 We write <m>\ln(x) = \log_{e}(x) = \frac{\log(x)}{\log(e)}</m>.
                 We graph both <m>f(x) = \ln(x)</m> and
                 <m>g(x) = \frac{\log(x)}{\log(e)}</m> and find both graphs appear to be identical. <figure xml:id="fig_logprop2"> <caption><m>y=f(x)=2^x</m> and
-                <m>y=g(x)=e^{x\ln(2)}</m></caption> <img src="figures/ExpLogsGraphics/ExpLogs04"/> </figure>
+                <m>y=g(x)=e^{x\ln(2)}</m></caption> <image source="figures/ExpLogsGraphics/ExpLogs04"></image> </figure>
               </p>
             </li>
           </ol>

--- a/ptx/PolarComplex.ptx
+++ b/ptx/PolarComplex.ptx
@@ -263,7 +263,7 @@
               just barely lies in the interval
               <m>(-\pi, \pi]</m> which means and <m>\operatorname{Arg}(z) =\pi</m>.
               We plot <m>z</m> along with the other numbers in this example in <xref ref="fig_polarcom1">Figure</xref>
-              below. <!-- <caption>Plots of the four complex numbers in Example \ref{plotmodargex}</caption> --> <sidebyside> <img src="figures/AppExtGraphics/PolarComplex-2"/> </sidebyside>
+              below. <!-- <caption>Plots of the four complex numbers in Example \ref{plotmodargex}</caption> --> <sidebyside> <image source="figures/AppExtGraphics/PolarComplex-2"></image> </sidebyside>
             </p>
             </li>
           </ol>
@@ -1045,8 +1045,8 @@
     <sidebyside>
       <tabular>
         <row>
-          <cell><img src="figures/AppExtGraphics/PolarComplex-4"/></cell>
-          <cell><img src="figures/AppExtGraphics/PolarComplex-5"/></cell>
+          <cell><image source="figures/AppExtGraphics/PolarComplex-4"></image></cell>
+          <cell><image source="figures/AppExtGraphics/PolarComplex-5"></image></cell>
         </row>
         <row>
           <cell>{ Multiplying <m>z</m> by <m>|w| = 2</m>}.</cell>
@@ -1072,8 +1072,8 @@
     <sidebyside>
       <tabular>
         <row>
-          <cell><img src="figures/AppExtGraphics/PolarComplex-6"/></cell>
-          <cell><img src="figures/AppExtGraphics/PolarComplex-7"/></cell>
+          <cell><image source="figures/AppExtGraphics/PolarComplex-6"></image></cell>
+          <cell><image source="figures/AppExtGraphics/PolarComplex-7"></image></cell>
         </row>
         <row>
           <cell>{ Dividing <m>z</m> by <m>|w| = 2</m>}.</cell>
@@ -1284,7 +1284,7 @@
                 <m>w_{0} = 1+i\sqrt{3}</m> and <m>w_{1} = -1-i\sqrt{3}</m>.
                 We can check our answers by squaring them and showing that we get <m>z= -2 + 2i\sqrt{3}</m>.
                 We've plotted the position of the two square roots along the circle <m>r=2</m> in <xref ref="fig_polarroot1">Figure</xref>. <figure xml:id="fig_polarroot1"> <caption>The two square roots of
-                <m>z=-2+2\sqrt{3}i</m></caption> <img src="figures/AppExtGraphics/PolarComplex01"/> </figure>
+                <m>z=-2+2\sqrt{3}i</m></caption> <image source="figures/AppExtGraphics/PolarComplex01"></image> </figure>
               </p>
             </li>
 
@@ -1300,7 +1300,7 @@
                 <m>w_{1} = -\sqrt{2} + i\sqrt{2}</m>,
                 <m>w_{2} = -\sqrt{2} - i\sqrt{2}</m> and <m>w_{3} = \sqrt{2} - i\sqrt{2}</m>.
                 We've plotted the four roots in <xref ref="fig_polarroot2">Figure</xref>.
-                Note how the roots are placed symmetrically about the circle <m>r=2</m>. <figure xml:id="fig_polarroot2"> <caption>The four fourth roots of <m>z=-16</m></caption> <img src="figures/AppExtGraphics/PolarComplex02"/> </figure>
+                Note how the roots are placed symmetrically about the circle <m>r=2</m>. <figure xml:id="fig_polarroot2"> <caption>The four fourth roots of <m>z=-16</m></caption> <image source="figures/AppExtGraphics/PolarComplex02"></image> </figure>
               </p>
             </li>
 
@@ -1318,7 +1318,7 @@
                 Since we are not explicitly told to do so,
                 we leave this as a good, but messy, exercise,
                 and plot the points in <xref ref="fig_polarroot3">Figure</xref>. <figure xml:id="fig_polarroot3"> <caption>The three third roots of
-                <m>z=\sqrt{2}+i\sqrt{2}</m></caption> <img src="figures/AppExtGraphics/PolarComplex03"/> </figure>
+                <m>z=\sqrt{2}+i\sqrt{2}</m></caption> <image source="figures/AppExtGraphics/PolarComplex03"></image> </figure>
               </p>
             </li>
 
@@ -1338,7 +1338,7 @@
                 we could approximate our answers using a calculator,
                 and we leave this as an exercise.
                 Once more, we plot the roots,
-                which in this case all lie on the unit circle. <figure xml:id="fig_polarroot4"> <caption>The five fifth roots of <m>1</m></caption> <img src="figures/AppExtGraphics/PolarComplex04"/> </figure>
+                which in this case all lie on the unit circle. <figure xml:id="fig_polarroot4"> <caption>The five fifth roots of <m>1</m></caption> <image source="figures/AppExtGraphics/PolarComplex04"></image> </figure>
               </p>
             </li>
           </ol>

--- a/ptx/Polydivision.ptx
+++ b/ptx/Polydivision.ptx
@@ -15,7 +15,7 @@
 
     <figure xml:id="fig_polyzeros1">
       <caption>The graph <m>y=x^3+4x^2-5x-14</m></caption>
-      <img src="figures/PolynomialsGraphics/CubicIrrRootZeros"/>
+      <image source="figures/PolynomialsGraphics/CubicIrrRootZeros"></image>
     </figure>
 
     <p>

--- a/ptx/QuadraticFunctions.ptx
+++ b/ptx/QuadraticFunctions.ptx
@@ -42,7 +42,7 @@
 
     <figure xml:id="fig_parabstd">
       <caption>The graph of the basic quadratic function <m>f(x)=x^2</m></caption>
-      <img src="figures/LinearQuadraticGraphics/QuadraticFunctions-1"/>
+      <image source="figures/LinearQuadraticGraphics/QuadraticFunctions-1"></image>
     </figure>
 
     <p>
@@ -80,7 +80,7 @@
           <ol>
             <figure xml:id="fig_parabgr1">
               <caption>The graph <m>y=x^2</m> with points labelled</caption>
-              <img src="figures/LinearQuadraticGraphics/QuadraticFunctions-2"/>
+              <image source="figures/LinearQuadraticGraphics/QuadraticFunctions-2"></image>
             </figure>
 
             <li>
@@ -101,7 +101,7 @@
                 <m>(-3,1)</m> to <m>(-3,-2)</m>,
                 <m>(-2,0)</m> to <m>(-2,3)</m>,
                 <m>(-1,1)</m> to <m>(-1,-2)</m> and <m>(0,4)</m> to <m>(0,1)</m>.
-                We connect the dots in parabolic fashion to get the graph in <xref ref="fig_parabgr2">Figure</xref>. <figure xml:id="fig_parabgr2"> <caption><m>g(x)=f(x+2)-3 = (x+2)^2-3</m></caption> <img src="figures/LinearQuadraticGraphics/QuadraticFunctions-3"/> </figure> From the graph,
+                We connect the dots in parabolic fashion to get the graph in <xref ref="fig_parabgr2">Figure</xref>. <figure xml:id="fig_parabgr2"> <caption><m>g(x)=f(x+2)-3 = (x+2)^2-3</m></caption> <image source="figures/LinearQuadraticGraphics/QuadraticFunctions-3"></image> </figure> From the graph,
                 we see that the vertex has moved from <m>(0,0)</m> on the graph of
                 <m>y = f(x)</m> to <m>(-2,-3)</m> on the graph of <m>y = g(x)</m>.
                 This sets <m>[-3, \infty)</m> as the range of <m>g</m>.
@@ -143,7 +143,7 @@
                 <m>(2,1)</m> to <m>(2,-1)</m>,
                 <m>(3,0)</m> to <m>(3,1)</m>,
                 <m>(4,1)</m> to <m>(4,-1)</m> and <m>(5,4)</m> to <m>(5,-7)</m>,
-                giving us the graph in <xref ref="fig_parabgr3">Figure</xref>. <figure xml:id="fig_parabgr3"> <caption><m>h(x) = -2f(x-3)+1 = -2(x-3)^2+1</m></caption> <img src="figures/LinearQuadraticGraphics/QuadraticFunctions-5"/> </figure> The vertex is <m>(3,1)</m> which makes the range of <m>h</m> <m>(-\infty, 1]</m>.
+                giving us the graph in <xref ref="fig_parabgr3">Figure</xref>. <figure xml:id="fig_parabgr3"> <caption><m>h(x) = -2f(x-3)+1 = -2(x-3)^2+1</m></caption> <image source="figures/LinearQuadraticGraphics/QuadraticFunctions-5"></image> </figure> The vertex is <m>(3,1)</m> which makes the range of <m>h</m> <m>(-\infty, 1]</m>.
                 From our graph, we know that there are two <m>x</m>-intercepts,
                 so we set <m>y = h(x) = 0</m> and solve.
                 We get <m>-2(x-3)^2+1 = 0</m> which gives <m>(x-3)^2 = \frac{1}{2}</m>.
@@ -304,13 +304,13 @@
       <caption>The axis of symmetry of a parabola</caption>
       <tabular>
         <row>
-          <cell><img src="figures/LinearQuadraticGraphics/QuadraticFunctions-6"/></cell>
+          <cell><image source="figures/LinearQuadraticGraphics/QuadraticFunctions-6"></image></cell>
         </row>
         <row>
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/LinearQuadraticGraphics/QuadraticFunctions-7"/></cell>
+          <cell><image source="figures/LinearQuadraticGraphics/QuadraticFunctions-7"></image></cell>
         </row>
       </tabular>
     </table>
@@ -385,7 +385,7 @@
 
                 <figure xml:id="fig_parabgr4">
                   <caption><m>f(x) = x^2-4x+3</m></caption>
-                  <img src="figures/LinearQuadraticGraphics/QuadraticFunctions-8"/>
+                  <image source="figures/LinearQuadraticGraphics/QuadraticFunctions-8"></image>
                 </figure>
 
                 Of course, we can always check our answer by multiplying out
@@ -430,7 +430,7 @@
 
                 <figure xml:id="fig_parabgr5">
                   <caption><m>g(x) = 6-x-x^2</m></caption>
-                  <img src="figures/LinearQuadraticGraphics/QuadraticFunctions-9"/>
+                  <image source="figures/LinearQuadraticGraphics/QuadraticFunctions-9"></image>
                 </figure>
 
                 From <m>g(x) =  -\left(x +\frac{1}{2}\right)^2 + \frac{25}{4}</m>,
@@ -736,7 +736,7 @@
 
                 <figure xml:id="fig_parabprofit">
                   <caption>The graph of the profit function <m>P(x)</m></caption>
-                  <img src="figures/LinearQuadraticGraphics/QuadraticFunctions-10"/>
+                  <image source="figures/LinearQuadraticGraphics/QuadraticFunctions-10"></image>
                 </figure>
 
               </p>
@@ -819,7 +819,7 @@
 
         <figure xml:id="fig_parabalpaca">
           <caption>A diagram of pasture dimensions</caption>
-          <img src="figures/LinearQuadraticGraphics/QuadraticFunctions-11"/>
+          <image source="figures/LinearQuadraticGraphics/QuadraticFunctions-11"></image>
         </figure>
 
         <p>
@@ -935,7 +935,7 @@
           <caption>Obtaining the graph of <m>f(x)=\lvert x^2-x-6\rvert</m></caption>
           <tabular>
             <row>
-              <cell><img src="figures/LinearQuadraticGraphics/QuadraticFunctions-12"/></cell>
+              <cell><image source="figures/LinearQuadraticGraphics/QuadraticFunctions-12"></image></cell>
             </row>
             <row>
               <cell><m>y=x^2-x-6</m></cell>
@@ -944,7 +944,7 @@
               <cell></cell>
             </row>
             <row>
-              <cell><img src="figures/LinearQuadraticGraphics/QuadraticFunctions-13"/></cell>
+              <cell><image source="figures/LinearQuadraticGraphics/QuadraticFunctions-13"></image></cell>
             </row>
             <row>
               <cell><m>y=\lvert x^2-x-6</m></cell>
@@ -1036,7 +1036,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/QuadraticFunctions-14"/>
+          <image source="figures/LinearQuadraticGraphics/QuadraticFunctions-14"></image>
         </p>
       </answer>
     </exercise>
@@ -1084,7 +1084,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/QuadraticFunctions-15"/>
+          <image source="figures/LinearQuadraticGraphics/QuadraticFunctions-15"></image>
         </p>
       </answer>
     </exercise>
@@ -1132,7 +1132,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/QuadraticFunctions-16"/>
+          <image source="figures/LinearQuadraticGraphics/QuadraticFunctions-16"></image>
         </p>
       </answer>
     </exercise>
@@ -1180,7 +1180,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/QuadraticFunctions-17"/>
+          <image source="figures/LinearQuadraticGraphics/QuadraticFunctions-17"></image>
         </p>
       </answer>
     </exercise>
@@ -1228,7 +1228,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/QuadraticFunctions-18"/>
+          <image source="figures/LinearQuadraticGraphics/QuadraticFunctions-18"></image>
         </p>
       </answer>
     </exercise>
@@ -1276,7 +1276,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/QuadraticFunctions-19"/>
+          <image source="figures/LinearQuadraticGraphics/QuadraticFunctions-19"></image>
         </p>
       </answer>
     </exercise>
@@ -1324,7 +1324,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/QuadraticFunctions-20"/>
+          <image source="figures/LinearQuadraticGraphics/QuadraticFunctions-20"></image>
         </p>
       </answer>
     </exercise>
@@ -1372,7 +1372,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/QuadraticFunctions-21"/>
+          <image source="figures/LinearQuadraticGraphics/QuadraticFunctions-21"></image>
         </p>
       </answer>
     </exercise>
@@ -1420,7 +1420,7 @@
         </p>
 
         <p>
-          <img src="figures/LinearQuadraticGraphics/QuadraticFunctions-22"/>
+          <image source="figures/LinearQuadraticGraphics/QuadraticFunctions-22"></image>
         </p>
 
         <p>
@@ -1989,7 +1989,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/LinearQuadraticGraphics/QuadraticFunctions-23"/>
+          <image source="figures/LinearQuadraticGraphics/QuadraticFunctions-23"></image>
         </p>
       </answer>
     </exercise>

--- a/ptx/RationalGraphs.ptx
+++ b/ptx/RationalGraphs.ptx
@@ -56,7 +56,7 @@
     </aside>
     <figure xml:id="fig_ratgraph1">
       <caption>The graph <m>y=h(x)</m> from <xref ref="ratfuncex">Example</xref></caption>
-      <img src="figures/RationalsGraphics/RationalGraphs-1"/>
+      <image source="figures/RationalsGraphics/RationalGraphs-1"></image>
     </figure>
 
     <p>
@@ -95,7 +95,7 @@
 
     <figure xml:id="fig_ratsd1">
       <caption>The sign diagram for the function <m>h(x)</m> from <xref ref="ratfuncex">Example</xref></caption>
-      <img src="figures/RationalsGraphics/RationalGraphs-2"/>
+      <image source="figures/RationalsGraphics/RationalGraphs-2"></image>
     </figure>
 
     <insight xml:id="rationalsigndiagram">
@@ -354,7 +354,7 @@
               </aside>
               <figure xml:id="fig_ratgraph2">
                 <caption>The graph <m>y=\frac{3x}{x^2-4}</m> near its vertical asymptotes</caption>
-                <img src="figures/RationalsGraphics/RationalGraphs-3"/>
+                <image source="figures/RationalsGraphics/RationalGraphs-3"></image>
               </figure>
 
             </li>
@@ -432,7 +432,7 @@
               </aside>
               <figure xml:id="fig_ratgraph3">
                 <caption>The end behavhiour of the graph <m>y=\frac{3x}{x^2-4}</m></caption>
-                <img src="figures/RationalsGraphics/RationalGraphs-4"/>
+                <image source="figures/RationalsGraphics/RationalGraphs-4"></image>
               </figure>
 
             </li>
@@ -450,8 +450,8 @@
                 <m>f(1)</m> is <m>(-)</m> and <m>f(3)</m> is <m>(+)</m>.
                 Combining this with our previous work,
                 we get the graph of <m>y=f(x)</m> in <xref ref="fig_ratgraph4">Figure</xref>. <figure xml:id="fig_ratsd2"> <caption>The sign diagram for
-                <m>f(x)=\frac{3x}{x^2-4}</m></caption> <img src="figures/RationalsGraphics/RationalGraphs-5"/> </figure> <figure xml:id="fig_ratgraph4"> <caption>The complete graph
-                <m>y=\frac{3x}{x^2-4}</m> for <xref ref="ex_ratgraph1">Example</xref></caption> <img src="figures/RationalsGraphics/RationalGraphs-6"/> </figure>
+                <m>f(x)=\frac{3x}{x^2-4}</m></caption> <image source="figures/RationalsGraphics/RationalGraphs-5"></image> </figure> <figure xml:id="fig_ratgraph4"> <caption>The complete graph
+                <m>y=\frac{3x}{x^2-4}</m> for <xref ref="ex_ratgraph1">Example</xref></caption> <image source="figures/RationalsGraphics/RationalGraphs-6"></image> </figure>
               </p>
             </li>
           </ol>
@@ -566,7 +566,7 @@
 
               <figure xml:id="fig_ratgraph5">
                 <caption>The graph <m>y=\frac{2x^2-3x-5}{x^2-x-6}</m> near the vertical asymptotes</caption>
-                <img src="figures/RationalsGraphics/RationalGraphs-7"/>
+                <image source="figures/RationalsGraphics/RationalGraphs-7"></image>
               </figure>
 
             </li>
@@ -643,12 +643,12 @@
 
               <figure xml:id="fig_ratgraph6">
                 <caption>The end behaviour of <m>y=\frac{2x^2-3x-5}{x^2-x-6}</m></caption>
-                <img src="figures/RationalsGraphics/RationalGraphs-8"/>
+                <image source="figures/RationalsGraphics/RationalGraphs-8"></image>
               </figure>
 
               <figure xml:id="fig_ratsd3">
                 <caption>The sign diagram for <m>g(x)=\frac{2x^2-3x-5}{x^2-x-6}</m></caption>
-                <img src="figures/RationalsGraphics/RationalGraphs-9"/>
+                <image source="figures/RationalsGraphics/RationalGraphs-9"></image>
               </figure>
 
             </li>
@@ -683,7 +683,7 @@
                 Calculus verifies that at <m>x=13</m>,
                 we have such a minimum at exactly
                 <m>(13, 1.96)</m>. <figure xml:id="fig_ratgraph7"> <caption>The complete graph
-                <m>y=\frac{2x^2-3x-5}{x^2-x-6}</m> for <xref ref="ex_ratgraph2">Example</xref></caption> <img src="figures/RationalsGraphics/RationalGraphs-10"/> </figure>
+                <m>y=\frac{2x^2-3x-5}{x^2-x-6}</m> for <xref ref="ex_ratgraph2">Example</xref></caption> <image source="figures/RationalsGraphics/RationalGraphs-10"></image> </figure>
               </p>
             </li>
           </ol>
@@ -772,7 +772,7 @@
                     On the other side of <m>-2</m>,
                     as <m>x \rightarrow -2^{+}</m>,
                     we find that <m>h(x) \approx \frac{3}{\mbox{\scriptsize very small <m>(+)</m>} } \approx \mbox{very big <m>(+)</m>}</m>,
-                    so <m>h(x) \rightarrow \infty</m>. <figure xml:id="fig_ratgraph8"> <caption>The behaviour of <m>y=h(x)</m> near the hole and vertical asymptote</caption> <img src="figures/RationalsGraphics/RationalGraphs-11"/> </figure>
+                    so <m>h(x) \rightarrow \infty</m>. <figure xml:id="fig_ratgraph8"> <caption>The behaviour of <m>y=h(x)</m> near the hole and vertical asymptote</caption> <image source="figures/RationalsGraphics/RationalGraphs-11"></image> </figure>
                   </p>
                 </li>
 
@@ -849,7 +849,7 @@
 
             <figure xml:id="fig_ratgraph9">
               <caption>End behaviour for <m>y=h(x)</m></caption>
-              <img src="figures/RationalsGraphics/RationalGraphs-12"/>
+              <image source="figures/RationalsGraphics/RationalGraphs-12"></image>
             </figure>
 
           </li>
@@ -873,12 +873,12 @@
         <figure xml:id="fig_ratsd4">
           <caption>The sign diagram for
           <m>h(x)=\frac{2x^3+5x^2+4x+1}{x^2+3x+2}</m></caption>
-          <img src="figures/RationalsGraphics/RationalGraphs-13"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-13"></image>
         </figure>
 
         <figure xml:id="fig_ratgraph10">
           <caption>The graph <m>y=h(x)</m> for <xref ref="ex_ratgraph3">Example</xref></caption>
-          <img src="figures/RationalsGraphics/RationalGraphs-14"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-14"></image>
         </figure>
 
         <p>
@@ -957,7 +957,7 @@
               So the graph <m>y=r(x)</m> is a little bit <em>above</em>
               the graph of the parabola <m>y=x^2-1</m> as <m>x \rightarrow \pm \infty</m>.
               Graphically,
-              we have <xref ref="fig_ratgraph11">Figure</xref>. <figure xml:id="fig_ratgraph11"> <caption>Comparing <m>y=r(x)</m> to <m>y=x^2-1</m></caption> <img src="figures/RationalsGraphics/RationalGraphs-15"/> </figure>
+              we have <xref ref="fig_ratgraph11">Figure</xref>. <figure xml:id="fig_ratgraph11"> <caption>Comparing <m>y=r(x)</m> to <m>y=x^2-1</m></caption> <image source="figures/RationalsGraphics/RationalGraphs-15"></image> </figure>
             </p>
           </li>
 
@@ -986,7 +986,7 @@
           <caption>The limitations of our Precalculus methods</caption>
           <tabular>
             <row>
-              <cell><img src="figures/RationalsGraphics/RationalGraphs-16"/></cell>
+              <cell><image source="figures/RationalsGraphics/RationalGraphs-16"></image></cell>
             </row>
             <row>
               <cell>Plotting by hand (without calculus)</cell>
@@ -995,7 +995,7 @@
               <cell></cell>
             </row>
             <row>
-              <cell><img src="figures/RationalsGraphics/Rationals09"/></cell>
+              <cell><image source="figures/RationalsGraphics/Rationals09"></image></cell>
             </row>
             <row>
               <cell>Plotting with GeoGebra</cell>
@@ -1074,7 +1074,7 @@
         </p>
 
         <p>
-          <img src="figures/RationalsGraphics/RationalGraphs-17"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-17"></image>
         </p>
       </answer>
     </exercise>
@@ -1126,7 +1126,7 @@
         </p>
 
         <p>
-          <img src="figures/RationalsGraphics/RationalGraphs-18"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-18"></image>
         </p>
       </answer>
     </exercise>
@@ -1178,7 +1178,7 @@
         </p>
 
         <p>
-          <img src="figures/RationalsGraphics/RationalGraphs-19"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-19"></image>
         </p>
       </answer>
     </exercise>
@@ -1238,7 +1238,7 @@
         </p>
 
         <p>
-          <img src="figures/RationalsGraphics/RationalGraphs-20"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-20"></image>
         </p>
       </answer>
     </exercise>
@@ -1298,7 +1298,7 @@
         </p>
 
         <p>
-          <img src="figures/RationalsGraphics/RationalGraphs-21"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-21"></image>
         </p>
       </answer>
     </exercise>
@@ -1358,7 +1358,7 @@
         </p>
 
         <p>
-          <img src="figures/RationalsGraphics/RationalGraphs-22"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-22"></image>
         </p>
       </answer>
     </exercise>
@@ -1407,7 +1407,7 @@
         </p>
 
         <p>
-          <img src="figures/RationalsGraphics/RationalGraphs-23"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-23"></image>
         </p>
       </answer>
     </exercise>
@@ -1472,7 +1472,7 @@
         </p>
 
         <p>
-          <img src="figures/RationalsGraphics/RationalGraphs-24"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-24"></image>
         </p>
       </answer>
     </exercise>
@@ -1529,7 +1529,7 @@
         </p>
 
         <p>
-          <img src="figures/RationalsGraphics/RationalGraphs-25"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-25"></image>
         </p>
       </answer>
     </exercise>
@@ -1595,7 +1595,7 @@
         </p>
 
         <p>
-          <img src="figures/RationalsGraphics/RationalGraphs-26"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-26"></image>
         </p>
       </answer>
     </exercise>
@@ -1649,7 +1649,7 @@
         </p>
 
         <p>
-          <img src="figures/RationalsGraphics/RationalGraphs-27"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-27"></image>
         </p>
       </answer>
     </exercise>
@@ -1703,7 +1703,7 @@
         </p>
 
         <p>
-          <img src="figures/RationalsGraphics/RationalGraphs-28"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-28"></image>
         </p>
       </answer>
     </exercise>
@@ -1761,7 +1761,7 @@
         </p>
 
         <p>
-          <img src="figures/RationalsGraphics/RationalGraphs-29"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-29"></image>
         </p>
       </answer>
     </exercise>
@@ -1823,7 +1823,7 @@
         </p>
 
         <p>
-          <img src="figures/RationalsGraphics/RationalGraphs-30"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-30"></image>
         </p>
       </answer>
     </exercise>
@@ -1865,7 +1865,7 @@
         </p>
 
         <p>
-          <img src="figures/RationalsGraphics/RationalGraphs-31"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-31"></image>
         </p>
       </answer>
     </exercise>
@@ -1932,7 +1932,7 @@
         </p>
 
         <p>
-          <img src="figures/RationalsGraphics/RationalGraphs-32"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-32"></image>
         </p>
       </answer>
     </exercise>
@@ -1960,7 +1960,7 @@
         </p>
 
         <p>
-          <img src="figures/RationalsGraphics/RationalGraphs-33"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-33"></image>
         </p>
       </answer>
     </exercise>
@@ -2000,7 +2000,7 @@
         </p>
 
         <p>
-          <img src="figures/RationalsGraphics/RationalGraphs-34"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-34"></image>
         </p>
       </answer>
     </exercise>
@@ -2024,7 +2024,7 @@
         </p>
 
         <p>
-          <img src="figures/RationalsGraphics/RationalGraphs-35"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-35"></image>
         </p>
       </answer>
     </exercise>
@@ -2064,7 +2064,7 @@
         </p>
 
         <p>
-          <img src="figures/RationalsGraphics/RationalGraphs-36"/>
+          <image source="figures/RationalsGraphics/RationalGraphs-36"></image>
         </p>
       </answer>
     </exercise>

--- a/ptx/RationalIneq.ptx
+++ b/ptx/RationalIneq.ptx
@@ -90,7 +90,7 @@
 
                 <figure xml:id="fig_ratineq1">
                   <caption>The sign diagram for the inequality in <xref ref="ex_ratineq">Example</xref></caption>
-                  <img src="figures/RationalsGraphics/RationalIneq-1"/>
+                  <image source="figures/RationalsGraphics/RationalIneq-1"></image>
                 </figure>
 
                 We are interested in where <m>r(x) \geq 0</m>.
@@ -111,7 +111,7 @@
                 the solutions to <m>f(x)=g(x)</m> are the <m>x</m>-coordinates of the points where the graphs of <m>y=f(x)</m> and <m>y=g(x)</m> intersect.
                 The solution to <m>f(x) \geq g(x)</m> represents not only where the graphs meet,
                 but the intervals over which the graph of <m>y=f(x)</m> is above (<m>></m>) the graph of <m>g(x)</m>.
-                Entering these two functions into GeoGebra gives us <xref ref="fig_ratineq2">Figure</xref>. <figure xml:id="fig_ratineq2"> <caption>The initial plot of <m>f(x)</m> and <m>g(x)</m></caption> <img src="figures/RationalsGraphics/Rationals10"/> </figure> <figure xml:id="fig_ratineq3"> <caption>Zooming in to find the intersection points</caption> <img src="figures/RationalsGraphics/Rationals11"/> </figure> Zooming in and using the Intersect tool,
+                Entering these two functions into GeoGebra gives us <xref ref="fig_ratineq2">Figure</xref>. <figure xml:id="fig_ratineq2"> <caption>The initial plot of <m>f(x)</m> and <m>g(x)</m></caption> <image source="figures/RationalsGraphics/Rationals10"></image> </figure> <figure xml:id="fig_ratineq3"> <caption>Zooming in to find the intersection points</caption> <image source="figures/RationalsGraphics/Rationals11"></image> </figure> Zooming in and using the Intersect tool,
                 we see in <xref ref="fig_ratineq3">Figure</xref>
                 that the graphs cross when <m>x=-\frac{1}{2}</m> and <m>x=0</m>.
                 It is clear from the calculator that the graph of <m>y=f(x)</m> is above the graph of <m>y=g(x)</m> on
@@ -519,7 +519,7 @@
 
                 <figure xml:id="fig_ratineqsd">
                   <caption>The sign digram for <m>r(x)</m></caption>
-                  <img src="figures/RationalsGraphics/RationalIneq-2"/>
+                  <image source="figures/RationalsGraphics/RationalIneq-2"></image>
                 </figure>
 
                 In the context of the problem,
@@ -578,7 +578,7 @@
 
         <figure xml:id="fig_ratineq4">
           <caption>The box in <xref ref="boxnotopfixedvolume">Example</xref></caption>
-          <img src="figures/RationalsGraphics/RationalIneq-3"/>
+          <image source="figures/RationalsGraphics/RationalIneq-3"></image>
         </figure>
 
         <ol>
@@ -668,7 +668,7 @@
 
                 <figure xml:id="fig_ratineqsd2">
                   <caption>The sign digram for <m>h(x)</m></caption>
-                  <img src="figures/RationalsGraphics/RationalIneq-4"/>
+                  <image source="figures/RationalsGraphics/RationalIneq-4"></image>
                 </figure>
 
                 We see <m>r(x) > 0</m> on <m>(0,10)</m>,
@@ -732,7 +732,7 @@
                 This means that the width and depth of the box should each measure approximately <m>12.60</m> centimetres.
                 To determine the height,
           we find <m>h(12.60) \approx 6.30</m>,
-                so the height of the box should be approximately <m>6.30</m> centimetres. <figure xml:id="fig_ratineqlast"> <caption>Minimizing the surface area in <xref ref="boxnotopfixedvolume">Example</xref></caption> <img src="figures/RationalsGraphics/Rationals12"/> </figure>
+                so the height of the box should be approximately <m>6.30</m> centimetres. <figure xml:id="fig_ratineqlast"> <caption>Minimizing the surface area in <xref ref="boxnotopfixedvolume">Example</xref></caption> <image source="figures/RationalsGraphics/Rationals12"></image> </figure>
               </p>
             </li>
           </ol>

--- a/ptx/RealNumberArithmetic.ptx
+++ b/ptx/RealNumberArithmetic.ptx
@@ -523,11 +523,11 @@
 
             <li>
               <p>
-                <m>\dfrac{\dfrac{12}{5} - \dfrac{7}{24}}{1 + \left(\dfrac{12}{5}\right) \left(\dfrac{7}{24}\right)}</m> \setcounter{HW}{\value{enumi}}
+                <m>\dfrac{\dfrac{12}{5} - \dfrac{7}{24}}{1 + \left(\dfrac{12}{5}\right) \left(\dfrac{7}{24}\right)}</m>
               </p>
             </li>
 
-            \setcounter{enumi}{\value{HW}}
+            
 
             <li>
               <p>
@@ -537,7 +537,7 @@
 
             <li>
               <p>
-                <m>\left(\dfrac{3}{5} \right) \left(\dfrac{5}{13} \right) - \left(\dfrac{4}{5}\right) \left( - \dfrac{12}{13}\right)</m> \setcounter{HW}{\value{enumi}}
+                <m>\left(\dfrac{3}{5} \right) \left(\dfrac{5}{13} \right) - \left(\dfrac{4}{5}\right) \left( - \dfrac{12}{13}\right)</m>
               </p>
             </li>
           </ol>
@@ -903,11 +903,11 @@
 
             <li>
               <p>
-                <m>12(-5)(-5+3)^{-4}+6(-5)^2(-4)(-5+3)^{-5}</m> \setcounter{HW}{\value{enumi}}
+                <m>12(-5)(-5+3)^{-4}+6(-5)^2(-4)(-5+3)^{-5}</m>
               </p>
             </li>
 
-            \setcounter{enumi}{\value{HW}}
+            
 
             <li>
               <p>

--- a/ptx/RealZeros.ptx
+++ b/ptx/RealZeros.ptx
@@ -206,7 +206,7 @@
                 We plot <m>f(x)</m> using GeoGebra,
                 and zoom in to show the portion of the graph where <m>-4\leq x\leq 4</m>:
                 see <xref ref="fig_realzero1">Figure</xref>. <figure xml:id="fig_realzero1"> <caption>The graph
-                <m>y=f(x)=2x^4+4x^3-x^2-6x-3</m></caption> <img src="figures/PolynomialsGraphics/RealZero1"/> </figure>
+                <m>y=f(x)=2x^4+4x^3-x^2-6x-3</m></caption> <image source="figures/PolynomialsGraphics/RealZero1"></image> </figure>
               </p>
             </li>
 
@@ -307,7 +307,7 @@
     </aside>
     <figure xml:id="fig_realzero2">
       <caption>Zooming in on the repeated zero in <xref ref="ex_rzerotech">Example</xref></caption>
-      <img src="figures/PolynomialsGraphics/RealZero2"/>
+      <image source="figures/PolynomialsGraphics/RealZero2"></image>
     </figure>
 
     <p>
@@ -374,7 +374,7 @@
                 Zooming in a bit gives the graph (b).
                 Based on the graph,
                 none of our rational zeros will work. (Do you see why not?) <table xml:id="fig_realzero3"> <caption>Two views of the graph
-                <m>y=f(x)=x^4+x^2-12</m> in <xref ref="usubex">Example</xref></caption> <tabular> <row> <cell><img src="figures/PolynomialsGraphics/RealZero3"/></cell> </row> <row> <cell>(a)</cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/PolynomialsGraphics/RealZero4"/></cell> </row> <row> <cell>(b)</cell> </row> </tabular> </table>
+                <m>y=f(x)=x^4+x^2-12</m> in <xref ref="usubex">Example</xref></caption> <tabular> <row> <cell><image source="figures/PolynomialsGraphics/RealZero3"></image></cell> </row> <row> <cell>(a)</cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/PolynomialsGraphics/RealZero4"></image></cell> </row> <row> <cell>(b)</cell> </row> </tabular> </table>
               </p>
             </li>
 
@@ -600,7 +600,7 @@
 
     <figure xml:id="fig_realzero4">
       <caption>The graph <m>y=2x^4+4x^3-x^2-6x-3</m></caption>
-      <img src="figures/PolynomialsGraphics/RealZeros_New-1"/>
+      <image source="figures/PolynomialsGraphics/RealZeros_New-1"></image>
     </figure>
 
     <p>
@@ -717,7 +717,7 @@
                 We found the zeros of
           <m>p(x) = 2x^5-3x^4+6x^3-8x^2+3</m> in part 1 to be <m>x=-\frac{1}{2}</m> and <m>x=1</m>.
                 We construct our sign diagram as before,
-                giving us <xref ref="fig_sdzeros1">Figure</xref>. <figure xml:id="fig_sdzeros1"> <caption>The sign diagram for <m>p(x)</m> in <xref ref="polyeqineqexample">Example</xref></caption> <img src="figures/PolynomialsGraphics/RealZeros_New-2"/> </figure> The solution to
+                giving us <xref ref="fig_sdzeros1">Figure</xref>. <figure xml:id="fig_sdzeros1"> <caption>The sign diagram for <m>p(x)</m> in <xref ref="polyeqineqexample">Example</xref></caption> <image source="figures/PolynomialsGraphics/RealZeros_New-2"></image> </figure> The solution to
                 <m>p(x) \lt 0</m> is <m>\left(-\infty, -\frac{1}{2}\right)</m>,
                 and we know <m>p(x) = 0</m> at <m>x=-\frac{1}{2}</m> and <m>x=1</m>.
                 Hence, the solution to
@@ -750,7 +750,7 @@
       <caption>The polynomials <m>f(x)</m> and <m>g(x)</m> from <xref ref="polyeqineqexample">Example</xref>, part 3</caption>
       <tabular>
         <row>
-          <cell><img src="figures/PolynomialsGraphics/RealZero5"/></cell>
+          <cell><image source="figures/PolynomialsGraphics/RealZero5"></image></cell>
         </row>
         <row>
           <cell>(a)</cell>
@@ -759,7 +759,7 @@
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/PolynomialsGraphics/RealZero6"/></cell>
+          <cell><image source="figures/PolynomialsGraphics/RealZero6"></image></cell>
         </row>
         <row>
           <cell>(b)</cell>
@@ -810,7 +810,7 @@
 
         <figure xml:id="fig_sdzeros2">
           <caption>The sign diagram for <m>P(x)</m> in <xref ref="ex_zerosappl">Example</xref></caption>
-          <img src="figures/PolynomialsGraphics/RealZeros_New-3"/>
+          <image source="figures/PolynomialsGraphics/RealZeros_New-3"></image>
         </figure>
 
         <p>
@@ -838,7 +838,7 @@
 
     <figure xml:id="fig_applzeroeg">
       <caption>Plotting the profit function <m>P(x)</m> in <xref ref="ex_zerosappl">Example</xref></caption>
-      <img src="figures/PolynomialsGraphics/RealZero7"/>
+      <image source="figures/PolynomialsGraphics/RealZero7"></image>
     </figure>
   </introduction>
 

--- a/ptx/Relations.ptx
+++ b/ptx/Relations.ptx
@@ -43,7 +43,7 @@
 
     <figure xml:id="fig_relgraph">
       <caption>The graph of the relation <m>R=\{(-2,1), (4,3), (0,-3)\}</m></caption>
-      <img src="figures/RelationsandFunctionsGraphics/Relations-1"/>
+      <image source="figures/RelationsandFunctionsGraphics/Relations-1"></image>
     </figure>
 
     <p>
@@ -52,7 +52,7 @@
 
     <figure xml:id="fig_relgraphA">
       <caption>The graph of <m>A</m></caption>
-      <img src="figures/RelationsandFunctionsGraphics/Relations-2"/>
+      <image source="figures/RelationsandFunctionsGraphics/Relations-2"></image>
     </figure>
 
     <example xml:id="relationgraphingexample">
@@ -147,7 +147,7 @@
                 </aside>
                 <figure xml:id="fig_relgraphHLS">
                   <caption>The graph of <m>HLS_1</m></caption>
-                  <img src="figures/RelationsandFunctionsGraphics/Relations-3"/>
+                  <image source="figures/RelationsandFunctionsGraphics/Relations-3"></image>
                 </figure>
 
               </p>
@@ -171,7 +171,7 @@
                 There is no real number that comes
                 <q>immediately before</q> <m>4</m>,
                 so to describe the set of points we want,
-                we draw the horizontal line segment starting at <m>(-2,3)</m> and draw an open circle at <m>(4,3)</m> as depicted below on the right. <table xml:id="HLS2opencircle"> <caption>Getting the right graph for <m>HLS_2</m></caption> <tabular> <row> <cell><img src="figures/RelationsandFunctionsGraphics/Relations-4"/></cell> </row> <row> <cell>This is NOT the correct graph of <m>HLS_{2}</m></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/RelationsandFunctionsGraphics/Relations-5"/></cell> </row> <row> <cell>The graph of <m>HLS_{2}</m></cell> </row> </tabular> </table>
+                we draw the horizontal line segment starting at <m>(-2,3)</m> and draw an open circle at <m>(4,3)</m> as depicted below on the right. <table xml:id="HLS2opencircle"> <caption>Getting the right graph for <m>HLS_2</m></caption> <tabular> <row> <cell><image source="figures/RelationsandFunctionsGraphics/Relations-4"></image></cell> </row> <row> <cell>This is NOT the correct graph of <m>HLS_{2}</m></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/RelationsandFunctionsGraphics/Relations-5"></image></cell> </row> <row> <cell>The graph of <m>HLS_{2}</m></cell> </row> </tabular> </table>
               </p>
             </li>
 
@@ -196,7 +196,7 @@
                 the relation <m>H = \{ (x,y) \, | \, y = -2 \}</m> is similar to the relation <m>V</m> above in that only one of the coordinates,
                 in this case the <m>y</m>-coordinate, is specified,
                 leaving <m>x</m> to be <q>free</q>.
-                Plotting some representative points gives us the horizontal line <m>y=-2</m>. <figure xml:id="fig_relgraphV"> <caption>The graph of <m>V</m></caption> <img src="figures/RelationsandFunctionsGraphics/Relations-6"/> </figure> <figure xml:id="fig_relgraphH"> <caption>The graph of <m>H</m></caption> <img src="figures/RelationsandFunctionsGraphics/Relations-7"/> </figure>
+                Plotting some representative points gives us the horizontal line <m>y=-2</m>. <figure xml:id="fig_relgraphV"> <caption>The graph of <m>V</m></caption> <image source="figures/RelationsandFunctionsGraphics/Relations-6"></image> </figure> <figure xml:id="fig_relgraphH"> <caption>The graph of <m>H</m></caption> <image source="figures/RelationsandFunctionsGraphics/Relations-7"></image> </figure>
               </p>
             </li>
 
@@ -469,7 +469,7 @@
               <cell></cell>
             </row>
           </tabular>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-9"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-9"></image>
         </table>
 
         <p>
@@ -482,7 +482,7 @@
 
         <figure xml:id="fig_completecurve">
           <caption>The completed graph of <m>x^2+y^3=1</m></caption>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-10"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-10"></image>
         </figure>
 
         <p>
@@ -683,7 +683,7 @@
 
         <figure xml:id="fig_interceptplot">
           <caption>Plotting the data so far</caption>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-11"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-11"></image>
         </figure>
 
         <p>
@@ -715,7 +715,7 @@
 
         <figure xml:id="fig_finalplot">
           <caption>The final result</caption>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-12"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-12"></image>
         </figure>
       </solution>
     </example>
@@ -792,7 +792,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-23"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-23"></image>
         </p>
       </answer>
     </exercise>
@@ -806,7 +806,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-24"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-24"></image>
         </p>
       </answer>
     </exercise>
@@ -818,7 +818,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-25"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-25"></image>
         </p>
       </answer>
     </exercise>
@@ -830,7 +830,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-26"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-26"></image>
         </p>
       </answer>
     </exercise>
@@ -842,7 +842,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-27"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-27"></image>
         </p>
       </answer>
     </exercise>
@@ -854,7 +854,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-28"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-28"></image>
         </p>
       </answer>
     </exercise>
@@ -866,7 +866,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-29"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-29"></image>
         </p>
       </answer>
     </exercise>
@@ -878,7 +878,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-30"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-30"></image>
         </p>
       </answer>
     </exercise>
@@ -890,7 +890,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-31"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-31"></image>
         </p>
       </answer>
     </exercise>
@@ -902,7 +902,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-32"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-32"></image>
         </p>
       </answer>
     </exercise>
@@ -914,7 +914,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-33"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-33"></image>
         </p>
       </answer>
     </exercise>
@@ -926,7 +926,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-34"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-34"></image>
         </p>
       </answer>
     </exercise>
@@ -938,7 +938,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-35"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-35"></image>
         </p>
       </answer>
     </exercise>
@@ -950,7 +950,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-36"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-36"></image>
         </p>
       </answer>
     </exercise>
@@ -962,7 +962,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-37"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-37"></image>
         </p>
       </answer>
     </exercise>
@@ -974,7 +974,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-38"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-38"></image>
         </p>
       </answer>
     </exercise>
@@ -986,7 +986,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-39"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-39"></image>
         </p>
       </answer>
     </exercise>
@@ -998,7 +998,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-40"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-40"></image>
         </p>
       </answer>
     </exercise>
@@ -1010,7 +1010,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-41"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-41"></image>
         </p>
       </answer>
     </exercise>
@@ -1022,7 +1022,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-42"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-42"></image>
         </p>
       </answer>
     </exercise>
@@ -1033,7 +1033,7 @@
     <exercise>
       <statement>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-14"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-14"></image>
         </p>
 
         <p>
@@ -1049,7 +1049,7 @@
     <exercise>
       <statement>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-15"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-15"></image>
         </p>
 
         <p>
@@ -1065,7 +1065,7 @@
     <exercise>
       <statement>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-16"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-16"></image>
         </p>
 
         <p>
@@ -1081,7 +1081,7 @@
     <exercise>
       <statement>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-17"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-17"></image>
         </p>
 
         <p>
@@ -1097,7 +1097,7 @@
     <exercise>
       <statement>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-18"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-18"></image>
         </p>
 
         <p>
@@ -1113,7 +1113,7 @@
     <exercise>
       <statement>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-19"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-19"></image>
         </p>
 
         <p>
@@ -1129,7 +1129,7 @@
     <exercise>
       <statement>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-20"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-20"></image>
         </p>
 
         <p>
@@ -1145,7 +1145,7 @@
     <exercise>
       <statement>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-21"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-21"></image>
         </p>
 
         <p>
@@ -1161,7 +1161,7 @@
     <exercise>
       <statement>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-22"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-22"></image>
         </p>
 
         <p>
@@ -1177,7 +1177,7 @@
     <exercise>
       <statement>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-22"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-22"></image>
         </p>
 
         <p>
@@ -1201,7 +1201,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-43"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-43"></image>
         </p>
 
         <p>
@@ -1217,7 +1217,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-44"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-44"></image>
         </p>
 
         <p>
@@ -1233,7 +1233,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-45"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-45"></image>
         </p>
 
         <p>
@@ -1249,7 +1249,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-46"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-46"></image>
         </p>
 
         <p>
@@ -1265,7 +1265,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-47"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-47"></image>
         </p>
 
         <p>
@@ -1281,7 +1281,7 @@
       </statement>
       <answer>
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-48"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-48"></image>
         </p>
 
         <p>
@@ -1351,7 +1351,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-49"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-49"></image>
         </p>
 
         <p>
@@ -1387,7 +1387,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-50"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-50"></image>
         </p>
 
         <p>
@@ -1423,7 +1423,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-51"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-51"></image>
         </p>
 
         <p>
@@ -1459,7 +1459,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-52"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-52"></image>
         </p>
 
         <p>
@@ -1497,7 +1497,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-53"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-53"></image>
         </p>
 
         <p>
@@ -1533,7 +1533,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-54"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-54"></image>
         </p>
 
         <p>
@@ -1572,7 +1572,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-55"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-55"></image>
         </p>
 
         <p>
@@ -1608,7 +1608,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-56"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-56"></image>
         </p>
 
         <p>
@@ -1644,7 +1644,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-57"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-57"></image>
         </p>
 
         <p>
@@ -1680,7 +1680,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-58"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-58"></image>
         </p>
 
         <p>
@@ -1724,7 +1724,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-59"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-59"></image>
         </p>
 
         <p>
@@ -1760,7 +1760,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Relations-60"/>
+          <image source="figures/RelationsandFunctionsGraphics/Relations-60"></image>
         </p>
 
         <p>

--- a/ptx/SetTheory.ptx
+++ b/ptx/SetTheory.ptx
@@ -281,7 +281,7 @@
 
     <figure xml:id="venndiagram">
       <caption>A Venn diagram for <m>C</m>, <m>S</m>, and <m>V</m></caption>
-      <img src="figures/RelationsandFunctionsGraphics/SetTheory-1"/>
+      <image source="figures/RelationsandFunctionsGraphics/SetTheory-1"></image>
     </figure>
 
     <p>
@@ -323,7 +323,7 @@
     <sidebyside>
       <figure>
         <caption>Sets <m>A</m> and <m>B</m>.</caption>
-        <img src="figures/RelationsandFunctionsGraphics/SetTheory-2"/>
+        <image source="figures/RelationsandFunctionsGraphics/SetTheory-2"></image>
       </figure>
 
       <figure>
@@ -332,7 +332,7 @@
 
       <figure>
         <caption><m>A\cup B</m> is shaded.</caption>
-        <img src="figures/RelationsandFunctionsGraphics/SetTheory-4"/>
+        <image source="figures/RelationsandFunctionsGraphics/SetTheory-4"></image>
       </figure>
     </sidebyside>
     </figure>
@@ -667,7 +667,7 @@
 
     <figure xml:id="fig_numline">
       <caption>The real number line with two numbers <m>a</m> and <m>b</m>, where <m>a\lt b</m>.</caption>
-      <img src="figures/RelationsandFunctionsGraphics/SetTheory-5"/>
+      <image source="figures/RelationsandFunctionsGraphics/SetTheory-5"></image>
     </figure>
 
     <p>
@@ -794,7 +794,7 @@
           </row>
           <row>
             <cell>}</cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-1"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-1"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>
@@ -815,7 +815,7 @@
           </row>
           <row>
             <cell>}</cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-2"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-2"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>
@@ -836,7 +836,7 @@
           </row>
           <row>
             <cell>}</cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-3"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-3"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>
@@ -857,7 +857,7 @@
           </row>
           <row>
             <cell>}</cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-4"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-4"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>
@@ -878,7 +878,7 @@
           </row>
           <row>
             <cell>}</cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-5"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-5"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>
@@ -899,7 +899,7 @@
           </row>
           <row>
             <cell>}</cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-6"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-6"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>
@@ -920,7 +920,7 @@
           </row>
           <row>
             <cell>}</cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-7"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-7"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>
@@ -941,7 +941,7 @@
           </row>
           <row>
             <cell>}</cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-8"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-8"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>
@@ -962,7 +962,7 @@
           </row>
           <row>
             <cell>}</cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-9"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-9"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>
@@ -1033,7 +1033,7 @@
       </row>
       <row>
         <cell>}</cell>
-        <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-10"/></cell>
+        <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-10"></image></cell>
       </row>
       <row bottom="minor">
         <cell></cell>
@@ -1054,7 +1054,7 @@
       </row>
       <row>
         <cell>}</cell>
-        <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-11"/></cell>
+        <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-11"></image></cell>
       </row>
       <row bottom="minor">
         <cell></cell>
@@ -1075,7 +1075,7 @@
       </row>
       <row>
         <cell>}</cell>
-        <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-12"/></cell>
+        <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-12"></image></cell>
       </row>
       <row bottom="minor">
         <cell></cell>
@@ -1096,7 +1096,7 @@
       </row>
       <row>
         <cell>}</cell>
-        <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-13"/></cell>
+        <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-13"></image></cell>
       </row>
       <row bottom="minor">
         <cell></cell>
@@ -1124,7 +1124,7 @@
     <sidebyside>
       <figure>
         <caption><m>A = [-5,3)</m>,  <m>B = (1, \infty)</m></caption>
-        <img src="figures/RelationsandFunctionsGraphics/CartesianPlane-14"/>
+        <image source="figures/RelationsandFunctionsGraphics/CartesianPlane-14"></image>
       </figure>
 
       <figure>
@@ -1133,7 +1133,7 @@
 
       <figure>
         <caption><m>A \cup B = [-5,\infty)</m></caption>
-        <img src="figures/RelationsandFunctionsGraphics/CartesianPlane-16"/>
+        <image source="figures/RelationsandFunctionsGraphics/CartesianPlane-16"></image>
       </figure>
     </sidebyside>
     </figure>
@@ -1187,7 +1187,7 @@
                 <m>x \geq 2</m> corresponds to the interval <m>[2, \infty)</m>.
                 Since we are looking to describe the real numbers <m>x</m> in one of these <em>or</em> the other,
                 we have <m>\{ x \, | \, x \leq -2 \, \, \text{ or } \, \, x \geq 2 \} = (-\infty, -2] \cup [2, \infty)</m>. <figure xml:id="fig_eg1-1"> <caption>The set
-                <m>(-\infty, -2] \cup [2, \infty)</m></caption> <img src="figures/RelationsandFunctionsGraphics/CartesianPlane-17"/> </figure>
+                <m>(-\infty, -2] \cup [2, \infty)</m></caption> <image source="figures/RelationsandFunctionsGraphics/CartesianPlane-17"></image> </figure>
               </p>
             </li>
 
@@ -1200,7 +1200,7 @@
                 <m>(-\infty, 3)</m> and <m>(3,\infty)</m>.
                 Since the values of <m>x</m> could be in either one of these intervals <em>or</em> the other,
                 we have that <m>\{ x \, | \, x \neq 3 \} = (-\infty, 3) \cup (3,\infty)</m> <figure xml:id="fig_eg1-2"> <caption>The set
-                <m>(-\infty, 3) \cup (3, \infty)</m></caption> <img src="figures/RelationsandFunctionsGraphics/CartesianPlane-18"/> </figure>
+                <m>(-\infty, 3) \cup (3, \infty)</m></caption> <image source="figures/RelationsandFunctionsGraphics/CartesianPlane-18"></image> </figure>
               </p>
             </li>
 
@@ -1214,7 +1214,7 @@
                 Since the set describes real numbers which come from the first,
                 second <em>or</em> third interval,
                 we have <m>\{ x \, | \, x \neq \pm 3 \} = (-\infty, -3) \cup (-3,3) \cup (3, \infty)</m>. <figure xml:id="fig_eg1-3"> <caption>The set
-                <m>(-\infty, -3) \cup (-3,3) \cup (3, \infty)</m></caption> <img src="figures/RelationsandFunctionsGraphics/CartesianPlane-19"/> </figure>
+                <m>(-\infty, -3) \cup (-3,3) \cup (3, \infty)</m></caption> <image source="figures/RelationsandFunctionsGraphics/CartesianPlane-19"></image> </figure>
               </p>
             </li>
 
@@ -1227,7 +1227,7 @@
                 While we <em>could</em>
                 express the latter as <m>[5,5]</m> (Can you see why?), we choose to write our answer as
                 <m>\{ x \, | \, -1 \lt x \leq 3 \,\, \text{ or } \,\, x = 5\} = (-1,3] \cup \{ 5\}</m>. <figure xml:id="fig_eg1-4"> <caption>The set
-                <m>(-1,3] \cup \{ 5\}</m></caption> <img src="figures/RelationsandFunctionsGraphics/CartesianPlane-20"/> </figure>
+                <m>(-1,3] \cup \{ 5\}</m></caption> <image source="figures/RelationsandFunctionsGraphics/CartesianPlane-20"></image> </figure>
               </p>
             </li>
           </ol>
@@ -1302,7 +1302,7 @@
           <row>
             <cell></cell>
             <cell></cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-32"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-32"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>
@@ -1347,7 +1347,7 @@
           <row>
             <cell></cell>
             <cell></cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-33"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-33"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>
@@ -1392,7 +1392,7 @@
           <row>
             <cell></cell>
             <cell></cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-34"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-34"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>
@@ -1446,7 +1446,7 @@
           <row>
             <cell><m>\{x\,|\,-1\leq x\lt  5\}</m></cell>
             <cell><m>[-1,5)</m></cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-36"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-36"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>
@@ -1461,7 +1461,7 @@
           <row>
             <cell><m>\{x\,|\,0\leq x \lt  3\}</m></cell>
             <cell><m>[0,3)</m></cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-37"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-37"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>
@@ -1476,7 +1476,7 @@
           <row>
             <cell><m>\{x\,|\, 2 \lt   x \leq 7 \}</m></cell>
             <cell><m>(2,7]</m></cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-38"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-38"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>
@@ -1491,7 +1491,7 @@
           <row>
             <cell><m>\{x\,|\, -5 \lt   x \leq 0 \}</m></cell>
             <cell><m>(-5,0]</m></cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-39"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-39"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>
@@ -1506,7 +1506,7 @@
           <row>
             <cell><m>\{x\,|\, -3 \lt   x \lt  3 \}</m></cell>
             <cell><m>(-3,3)</m></cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-40"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-40"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>
@@ -1521,7 +1521,7 @@
           <row>
             <cell><m>\{x\,|\,5\leq x \leq 7\}</m></cell>
             <cell><m>[5,7]</m></cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-41"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-41"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>
@@ -1536,7 +1536,7 @@
           <row>
             <cell><m>\{x\,| \, x \leq 3 \}</m></cell>
             <cell><m>(-\infty, 3]</m></cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-42"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-42"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>
@@ -1551,7 +1551,7 @@
           <row>
             <cell><m>\{x\,| \, x \lt  9 \}</m></cell>
             <cell><m>(-\infty, 9)</m></cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-43"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-43"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>
@@ -1566,7 +1566,7 @@
           <row>
             <cell><m>\{x\,| \, x >  4 \}</m></cell>
             <cell><m>(4, \infty)</m></cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-44"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-44"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>
@@ -1581,7 +1581,7 @@
           <row>
             <cell><m>\{x\,| \, x \geq  -3 \}</m></cell>
             <cell><m>[-3, \infty)</m></cell>
-            <cell><img src="figures/RelationsandFunctionsGraphics/CartesianPlane-45"/></cell>
+            <cell><image source="figures/RelationsandFunctionsGraphics/CartesianPlane-45"></image></cell>
           </row>
           <row bottom="minor">
             <cell></cell>

--- a/ptx/Sinusoid.ptx
+++ b/ptx/Sinusoid.ptx
@@ -86,7 +86,7 @@
 
     <figure xml:id="genericsinsuoidfigure">
       <caption>Properties of a generic sinusoid <idx><h>sinusoid</h><h>graph of</h></idx></caption>
-      <img src="figures/AppExtGraphics/Sinusoid-1"/>
+      <image source="figures/AppExtGraphics/Sinusoid-1"></image>
     </figure>
 
     <p>
@@ -117,7 +117,7 @@
 
         <figure xml:id="fig_bigwheel">
           <caption>The Giant Wheel</caption>
-          <img src="figures/AppExtGraphics/Sinusoid-2"/>
+          <image source="figures/AppExtGraphics/Sinusoid-2"></image>
         </figure>
 
         <p>
@@ -157,7 +157,7 @@
 
         <figure xml:id="fig_sinusoid1">
           <caption>The graph <m>y=h(t)=64\sin\left(\frac{4\pi}{127}t-\frac{\pi}{2}\right)+72</m></caption>
-          <img src="figures/AppExtGraphics/Sinusoid-3"/>
+          <image source="figures/AppExtGraphics/Sinusoid-3"></image>
         </figure>
       </solution>
     </example>
@@ -261,9 +261,9 @@
     <sidebyside>
       <tabular>
         <row>
-          <cell><img src="figures/AppExtGraphics/Sinusoid-5"/></cell>
-          <cell><img src="figures/AppExtGraphics/Sinusoid-6"/></cell>
-          <cell><img src="figures/AppExtGraphics/Sinusoid-7"/></cell>
+          <cell><image source="figures/AppExtGraphics/Sinusoid-5"></image></cell>
+          <cell><image source="figures/AppExtGraphics/Sinusoid-6"></image></cell>
+          <cell><image source="figures/AppExtGraphics/Sinusoid-7"></image></cell>
         </row>
         <row>
           <cell><m>x(t) = 0</m> at the</cell>
@@ -418,7 +418,7 @@
                 <m>x(t) \lt 0</m> means the object is above the equilibrium position,
                 the fact our graph in <xref ref="fig_sinusoid2">Figure</xref>
                 is crossing through the <m>t</m>-axis from positive <m>x</m> to negative <m>x</m> at
-                <m>t = \frac{\pi}{4}</m> confirms our answer. <figure xml:id="fig_sinusoid2"> <caption><m>y=x(t)=3\sin(2t+\frac{\pi}{2})</m> in <xref ref="freeudampedex">Example</xref>.1</caption> <img src="figures/AppExtGraphics/Sinusoid-8"/> </figure>
+                <m>t = \frac{\pi}{4}</m> confirms our answer. <figure xml:id="fig_sinusoid2"> <caption><m>y=x(t)=3\sin(2t+\frac{\pi}{2})</m> in <xref ref="freeudampedex">Example</xref>.1</caption> <image source="figures/AppExtGraphics/Sinusoid-8"></image> </figure>
               </p>
             </li>
 
@@ -465,7 +465,7 @@
                 <figure xml:id="fig_sinusoid3">
                   <caption>The graph
           <m>y=5\sin(2x+[\pi-\arcsin(\frac{3}{5})])</m> in <xref ref="freeudampedex">Example</xref>.2</caption>
-                  <img src="figures/AppExtGraphics/Sinusoid01"/>
+                  <image source="figures/AppExtGraphics/Sinusoid01"></image>
                 </figure>
 
               </p>
@@ -504,8 +504,8 @@
           <li>
             <p>
               Find the period of <m>x(t) = 5\sin(6t) - 5\sin\left(8t\right)</m>.
-              Graph <m>x(t)</m> using a graphing utility. <table xml:id="fig_sinusoid4"> <caption>Graphing <m>x(t)</m> in <xref ref="underdampedresonance">Example</xref>.1</caption> <tabular> <row> <cell><img src="figures/AppExtGraphics/Sinusoid02"/></cell> </row> <row> <cell>(a)
-              <m>y=10e^{-x/5}\sin(x+\frac{\pi}{3})</m></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/AppExtGraphics/Sinusoid03"/></cell> </row> <row> <cell>(b) {\color{blue} <m>y=10e^{-x/5}\sin(x+\frac{\pi}{3})</m>}, {\color{red}
+              Graph <m>x(t)</m> using a graphing utility. <table xml:id="fig_sinusoid4"> <caption>Graphing <m>x(t)</m> in <xref ref="underdampedresonance">Example</xref>.1</caption> <tabular> <row> <cell><image source="figures/AppExtGraphics/Sinusoid02"></image></cell> </row> <row> <cell>(a)
+              <m>y=10e^{-x/5}\sin(x+\frac{\pi}{3})</m></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/AppExtGraphics/Sinusoid03"></image></cell> </row> <row> <cell>(b) {\color{blue} <m>y=10e^{-x/5}\sin(x+\frac{\pi}{3})</m>}, {\color{red}
               <m>y=\pm 10e^{-x/5}</m>}</cell> </row> </tabular> </table>
             </p>
           </li>
@@ -566,7 +566,7 @@
                   <caption>Graphing <m>x(t)</m> in <xref ref="underdampedresonance">Example</xref>.2</caption>
                   <tabular>
                     <row>
-                      <cell><img src="figures/AppExtGraphics/Sinusoid04"/></cell>
+                      <cell><image source="figures/AppExtGraphics/Sinusoid04"></image></cell>
                     </row>
                     <row>
                       <cell>(a) <m>y=2(x+3)\sin(2x+\frac{\pi}{4}</m></cell>
@@ -575,7 +575,7 @@
                       <cell></cell>
                     </row>
                     <row>
-                      <cell><img src="figures/AppExtGraphics/Sinusoid05"/></cell>
+                      <cell><image source="figures/AppExtGraphics/Sinusoid05"></image></cell>
                     </row>
                     <row>
                       <cell>(b) {\color{blue}
@@ -617,7 +617,7 @@
                 <m>y = \pm 10 \sin(x)</m> over <m>[0,2\pi]</m>.
                 This is an example of the <q>beat</q> phenomena,
                 and the curious reader is invited to explore this concept as well. (A good place to start is this article on <url href="http://en.wikipedia.org/wiki/Beat_(acoustics)"><em>beats</em></url>.) <figure xml:id="fig_sinusoid6"> <caption>Graphing <m>x(t)</m> in <xref ref="underdampedresonance">Example</xref>.2</caption> <sidebyside> <figure> <caption>(a)
-          <m>y = 5\sin(6x) - 5\sin(8x)</m> over <m>[0,\pi]</m></caption> <img src="figures/AppExtGraphics/Sinusoid06"/> </figure> <figure> <caption>{\color{red} <m>y = \pm 10 \sin(x)</m> over
+          <m>y = 5\sin(6x) - 5\sin(8x)</m> over <m>[0,\pi]</m></caption> <image source="figures/AppExtGraphics/Sinusoid06"></image> </figure> <figure> <caption>{\color{red} <m>y = \pm 10 \sin(x)</m> over
                 <m>[0,2\pi]</m>}</caption> (b) {\color{blue}
                 <m>y = 5\sin(6x) - 5\sin(8x)</m>} and </figure> </sidebyside> </figure>
               </p>
@@ -790,7 +790,7 @@
           Check with your friendly neighborhood physicist to make sure.</fn></p>
 
         <p>
-          <img src="figures/AppExtGraphics/Sinusoid-9"/>
+          <image source="figures/AppExtGraphics/Sinusoid-9"></image>
         </p>
 
         <p>

--- a/ptx/TheUnitCircle.ptx
+++ b/ptx/TheUnitCircle.ptx
@@ -30,7 +30,7 @@
 
     <figure xml:id="fig_circle1">
       <caption>Defining <m>\cos(\theta)</m> and <m>\sin(\theta)</m></caption>
-      <img src="figures/IntroTrigGraphics/TheUnitCircle-2"/>
+      <image source="figures/IntroTrigGraphics/TheUnitCircle-2"></image>
     </figure>
 
     <aside>
@@ -94,7 +94,7 @@
                 Hence,
           the point we seek is <m>(0,-1)</m> so that <m>\cos\left(270^{\circ}\right) = 0</m> and
                 <m>\sin\left(270^{\circ}\right) = -1</m>. <figure xml:id="fig_circle2"> <caption>Finding <m>\cos(270^\circ)</m> and
-                <m>\sin(270^\circ)</m></caption> <img src="figures/IntroTrigGraphics/TheUnitCircle-3"/> </figure>
+                <m>\sin(270^\circ)</m></caption> <image source="figures/IntroTrigGraphics/TheUnitCircle-3"></image> </figure>
               </p>
             </li>
 
@@ -103,7 +103,7 @@
                 The angle <m>\theta=-\pi</m> represents one half of a clockwise revolution so its terminal side lies on the negative <m>x</m>-axis.
                 The point on the Unit Circle that lies on the negative <m>x</m>-axis is <m>(-1,0)</m> which means <m>\cos(-\pi) = -1</m> and
                 <m>\sin(-\pi) = 0</m>. <figure xml:id="fig_circle3"> <caption>Finding <m>\cos(-\pi)</m> and
-                <m>\sin(-\pi)</m></caption> <img src="figures/IntroTrigGraphics/TheUnitCircle-4"/> </figure>
+                <m>\sin(-\pi)</m></caption> <image source="figures/IntroTrigGraphics/TheUnitCircle-4"></image> </figure>
               </p>
             </li>
 
@@ -126,8 +126,8 @@
               Since <m>P(x,y)</m> lies in the first quadrant, <m>x>0</m>,
               so <m>x = \cos\left(\frac{\pi}{4}\right) = \frac{\sqrt{2}}{2}</m> and with <m>y=x</m> we have
               <m>y = \sin\left(\frac{\pi}{4}\right) = \frac{\sqrt{2}}{2}</m>. <!-- <caption>Finding <m>\cos\left(\frac{\pi}{4}\right)</m> and
-              <m>\sin\left(\frac{\pi}{4}\right)</m></caption> --> <sidebyside> <tabular> {m{0.6\textwidth}m{0.4\textwidth}} <img src="figures/IntroTrigGraphics/TheUnitCircle-5"/>&amp;
-              <img src="figures/IntroTrigGraphics/TheUnitCircle-6"/>\\
+              <m>\sin\left(\frac{\pi}{4}\right)</m></caption> --> <sidebyside> <tabular> {m{0.6\textwidth}m{0.4\textwidth}} <image source="figures/IntroTrigGraphics/TheUnitCircle-5"></image>&amp;
+              <image source="figures/IntroTrigGraphics/TheUnitCircle-6"></image>\\
               <m>\theta=\frac{\pi}{4}</m> in standard position &amp;
               <m>45^{\circ} - 45^{\circ} - 90^{\circ}</m> triangle </tabular> </sidebyside>
             </p>
@@ -151,8 +151,8 @@
               or <m>x = \pm \frac{\sqrt{3}}{2}</m>.
               Here, <m>x > 0</m> so
           <m>x = \cos\left(\frac{\pi}{6}\right) = \frac{\sqrt{3}}{2}</m>. <!-- <caption>Finding <m>\cos\left(\frac{\pi}{6}\right)</m> and
-              <m>\sin\left(\frac{\pi}{6}\right)</m></caption> --> <sidebyside> <tabular> {m{0.5\textwidth}m{0.5\textwidth}} <img src="figures/IntroTrigGraphics/TheUnitCircle-7"/>&amp;
-              <img src="figures/IntroTrigGraphics/TheUnitCircle-8"/>\\
+              <m>\sin\left(\frac{\pi}{6}\right)</m></caption> --> <sidebyside> <tabular> {m{0.5\textwidth}m{0.5\textwidth}} <image source="figures/IntroTrigGraphics/TheUnitCircle-7"></image>&amp;
+              <image source="figures/IntroTrigGraphics/TheUnitCircle-8"></image>\\
               <m>\theta=\frac{\pi}{6}</m> in standard position &amp;
               <m>30^{\circ} - 60^{\circ} - 90^{\circ}</m> triangle </tabular> </sidebyside>
             </p>
@@ -168,8 +168,8 @@
               after the usual computations,
               find <m>x = \cos\left(\frac{\pi}{3}\right) = \frac{1}{2}</m> and
               <m>y = \sin\left(\frac{\pi}{3}\right) = \frac{\sqrt{3}}{2}</m>. <!-- <caption>Finding <m>\cos\left(\frac{\pi}{3}\right)</m> and
-              <m>\sin\left(\frac{\pi}{3}\right)</m></caption> --> <sidebyside> <tabular> {m{0.65\textwidth}m{0.35\textwidth}} <img src="figures/IntroTrigGraphics/TheUnitCircle-9"/>&amp;
-              <img src="figures/IntroTrigGraphics/TheUnitCircle-10"/>\\
+              <m>\sin\left(\frac{\pi}{3}\right)</m></caption> --> <sidebyside> <tabular> {m{0.65\textwidth}m{0.35\textwidth}} <image source="figures/IntroTrigGraphics/TheUnitCircle-9"></image>&amp;
+              <image source="figures/IntroTrigGraphics/TheUnitCircle-10"></image>\\
               <m>\theta=\frac{\pi}{3}</m> in standard position &amp;
               <m>30^{\circ} - 60^{\circ} - 90^{\circ}</m> triangle </tabular> </sidebyside>
             </p>
@@ -344,22 +344,22 @@
 
     <figure xml:id="fig_circle8">
       <caption>Reference angle <m>\alpha</m> for a Quadrant I angle</caption>
-      <img src="figures/IntroTrigGraphics/TheUnitCircle-13"/>
+      <image source="figures/IntroTrigGraphics/TheUnitCircle-13"></image>
     </figure>
 
     <figure xml:id="fig_circle9">
       <caption>Reference angle <m>\alpha</m> for a Quadrant II angle</caption>
-      <img src="figures/IntroTrigGraphics/TheUnitCircle-14"/>
+      <image source="figures/IntroTrigGraphics/TheUnitCircle-14"></image>
     </figure>
 
     <figure xml:id="fig_circle10">
       <caption>Reference angle <m>\alpha</m> for a Quadrant III angle</caption>
-      <img src="figures/IntroTrigGraphics/TheUnitCircle-15"/>
+      <image source="figures/IntroTrigGraphics/TheUnitCircle-15"></image>
     </figure>
 
     <figure xml:id="fig_circle11">
       <caption>Reference angle <m>\alpha</m> for a Quadrant IV angle</caption>
-      <img src="figures/IntroTrigGraphics/TheUnitCircle-16"/>
+      <image source="figures/IntroTrigGraphics/TheUnitCircle-16"></image>
     </figure>
 
     <p>
@@ -464,9 +464,9 @@
                 so the Reference Angle Theorem gives:
                 <m>\cos\left(\frac{11 \pi}{6} \right) = \cos\left(\frac{\pi}{6} \right) = \frac{\sqrt{3}}{2}</m> and
           <m>\sin\left(\frac{11\pi}{6}\right) = -\sin\left(\frac{\pi}{6}\right) = -\frac{1}{2}</m>. <figure xml:id="fig_circle12"> <caption>Finding <m>\cos\left(\frac{5\pi}{4}\right)</m> and
-          <m>\sin\left(\frac{5\pi}{4}\right)</m></caption> <img src="figures/IntroTrigGraphics/TheUnitCircle-17"/> </figure> <figure xml:id="fig_circle13"> <caption>Finding <m>\cos\left(\frac{11 \pi}{6}\right)</m> and
-                <m>\sin\left(\frac{11 \pi}{6}\right)</m></caption> <img src="figures/IntroTrigGraphics/TheUnitCircle-18"/> </figure> <figure xml:id="fig_circle14"> <caption>Finding <m>\cos\left(-\frac{5 \pi}{4}\right)</m> and
-                <m>\sin\left(-\frac{5 \pi}{4}\right)</m></caption> <img src="figures/IntroTrigGraphics/TheUnitCircle-19"/> </figure>
+          <m>\sin\left(\frac{5\pi}{4}\right)</m></caption> <image source="figures/IntroTrigGraphics/TheUnitCircle-17"></image> </figure> <figure xml:id="fig_circle13"> <caption>Finding <m>\cos\left(\frac{11 \pi}{6}\right)</m> and
+                <m>\sin\left(\frac{11 \pi}{6}\right)</m></caption> <image source="figures/IntroTrigGraphics/TheUnitCircle-18"></image> </figure> <figure xml:id="fig_circle14"> <caption>Finding <m>\cos\left(-\frac{5 \pi}{4}\right)</m> and
+                <m>\sin\left(-\frac{5 \pi}{4}\right)</m></caption> <image source="figures/IntroTrigGraphics/TheUnitCircle-19"></image> </figure>
               </p>
             </li>
 
@@ -491,7 +491,7 @@
                 Since <m>\theta</m> and <m>\alpha</m> are coterminal,
                 <m>\cos\left(\frac{7\pi}{3}\right) = \cos\left(\frac{\pi}{3}\right) = \frac{1}{2}</m> and
                 <m>\sin\left(\frac{7\pi}{3}\right) = \sin\left(\frac{\pi}{3}\right) = \frac{\sqrt{3}}{2}</m>. <figure xml:id="fig_circle15"> <caption>Finding <m>\cos\left(\frac{7 \pi}{3}\right)</m> and
-                <m>\sin\left(\frac{7 \pi}{3}\right)</m></caption> <img src="figures/IntroTrigGraphics/TheUnitCircle-20"/> </figure>
+                <m>\sin\left(\frac{7 \pi}{3}\right)</m></caption> <image source="figures/IntroTrigGraphics/TheUnitCircle-20"></image> </figure>
               </p>
             </li>
           </ol>
@@ -522,7 +522,7 @@
     <sidebyside>
       <idx><h>Unit Circle</h><h>important points</h></idx>
 
-      <img src="figures/IntroTrigGraphics/TheUnitCircle-21"/>
+      <image source="figures/IntroTrigGraphics/TheUnitCircle-21"></image>
     </sidebyside>
     <p>
       The next example summarizes all of the important ideas discussed thus far in the section.
@@ -588,7 +588,7 @@
                 Hence, <m>\sin(\alpha) = \frac{12}{13}</m>.
                 To plot <m>\alpha</m> in standard position,
                 we begin our rotation on the positive <m>x</m>-axis to the ray which contains the point <m>(\cos(\alpha), \sin(\alpha)) = \left(\frac{5}{13}, \frac{12}{13}\right)</m>:
-                see <xref ref="fig_circle16">Figure</xref>. <figure xml:id="fig_circle16"> <caption>Sketching <m>\alpha</m></caption> <img src="figures/IntroTrigGraphics/TheUnitCircle-22"/> </figure>
+                see <xref ref="fig_circle16">Figure</xref>. <figure xml:id="fig_circle16"> <caption>Sketching <m>\alpha</m></caption> <image source="figures/IntroTrigGraphics/TheUnitCircle-22"></image> </figure>
               </p>
             </li>
 
@@ -609,7 +609,7 @@
                   <m>\cos(\theta)</m> and <m>\sin(\theta)</m> are negative, hence,
                   <m>\cos(\theta) = - \frac{5}{13}</m> and
           <m>\sin(\theta) = - \frac{12}{13}</m>. <!-- <caption>Finding <m>\cos(\theta)</m> and
-          <m>\sin(\theta)</m> in Example \ref{advancedrefangleex}.2(a)</caption> --> <sidebyside> <tabular> <row> <cell><img src="figures/IntroTrigGraphics/TheUnitCircle-23"/></cell> <cell><img src="figures/IntroTrigGraphics/TheUnitCircle-24"/></cell> </row> <row> <cell>Visualizing
+          <m>\sin(\theta)</m> in Example \ref{advancedrefangleex}.2(a)</caption> --> <sidebyside> <tabular> <row> <cell><image source="figures/IntroTrigGraphics/TheUnitCircle-23"></image></cell> <cell><image source="figures/IntroTrigGraphics/TheUnitCircle-24"></image></cell> </row> <row> <cell>Visualizing
                   <m>\theta = \pi+\alpha</m></cell> <cell><m>\theta</m> has reference angle <m>\alpha</m></cell> </row> </tabular> </sidebyside>
                 </p>
               </li>
@@ -626,7 +626,7 @@
                 the Reference Angle Theorem gives:
                 <m>\cos(\theta) = \frac{5}{13}</m> and
           <m>\sin(\theta) = -\frac{12}{13}</m>. <!-- <caption>Finding <m>\cos(\theta)</m> and
-                <m>\sin(\theta)</m> in Example \ref{advancedrefangleex}.2(b)</caption> --> <sidebyside> <tabular> <row> <cell><img src="figures/IntroTrigGraphics/TheUnitCircle-25"/></cell> <cell><img src="figures/IntroTrigGraphics/TheUnitCircle-26"/></cell> </row> <row> <cell>Visualizing
+                <m>\sin(\theta)</m> in Example \ref{advancedrefangleex}.2(b)</caption> --> <sidebyside> <tabular> <row> <cell><image source="figures/IntroTrigGraphics/TheUnitCircle-25"></image></cell> <cell><image source="figures/IntroTrigGraphics/TheUnitCircle-26"></image></cell> </row> <row> <cell>Visualizing
                 <m>\theta = 2\pi-\alpha</m></cell> <cell><m>\theta</m> has reference angle <m>\alpha</m></cell> </row> </tabular> </sidebyside>
               </p>
               </li>
@@ -641,7 +641,7 @@
                 we end up in Quadrant II. Using the Reference Angle Theorem,
                 we get <m>\cos(\theta) = -\frac{5}{13}</m> and
           <m>\sin(\theta) = \frac{12}{13}</m>. <!-- <caption>Finding <m>\cos(\theta)</m> and
-                <m>\sin(\theta)</m> in Example \ref{advancedrefangleex}.2(c)</caption> --> <sidebyside> <tabular> <row> <cell><img src="figures/IntroTrigGraphics/TheUnitCircle-27"/></cell> <cell><img src="figures/IntroTrigGraphics/TheUnitCircle-28"/></cell> </row> <row> <cell>Visualizing
+                <m>\sin(\theta)</m> in Example \ref{advancedrefangleex}.2(c)</caption> --> <sidebyside> <tabular> <row> <cell><image source="figures/IntroTrigGraphics/TheUnitCircle-27"></image></cell> <cell><image source="figures/IntroTrigGraphics/TheUnitCircle-28"></image></cell> </row> <row> <cell>Visualizing
                 <m>\theta = 3\pi-\alpha</m></cell> <cell><m>\theta</m> has reference angle <m>\alpha</m></cell> </row> </tabular> </sidebyside>
               </p>
               </li>
@@ -661,7 +661,7 @@
                 Hence, <m>x = \cos(\theta) = -\frac{12}{13}</m>.
                 Similarly,
           we find <m>y = \sin(\theta) = \frac{5}{13}</m>. <!-- <caption>Finding <m>\cos(\theta)</m> and
-                <m>\sin(\theta)</m> in Example \ref{advancedrefangleex}.2(a)</caption> --> <sidebyside> <tabular> <row> <cell><img src="figures/IntroTrigGraphics/TheUnitCircle-29"/></cell> <cell><img src="figures/IntroTrigGraphics/TheUnitCircle-30"/></cell> </row> <row> <cell>Visualizing
+                <m>\sin(\theta)</m> in Example \ref{advancedrefangleex}.2(a)</caption> --> <sidebyside> <tabular> <row> <cell><image source="figures/IntroTrigGraphics/TheUnitCircle-29"></image></cell> <cell><image source="figures/IntroTrigGraphics/TheUnitCircle-30"></image></cell> </row> <row> <cell>Visualizing
                 <m>\theta = \frac{\pi}{2}+\alpha</m></cell> <cell>Using symmetry to determine <m>Q(x,y)</m></cell> </row> </tabular> </sidebyside>
               </p>
               </li>
@@ -764,7 +764,7 @@
               From this,
           we determine <m>\theta</m> is a Quadrant III or Quadrant IV angle with reference angle
               <m>\frac{\pi}{6}</m>. <!-- <caption>Angles with
-              <m>\sin(\theta)=-\frac{1}{2}</m></caption> --> <sidebyside> <tabular> <row> <cell><img src="figures/IntroTrigGraphics/TheUnitCircle-33"/></cell> <cell><img src="figures/IntroTrigGraphics/TheUnitCircle-34"/></cell> </row> </tabular> </sidebyside> In Quadrant III, one solution is <m>\frac{7\pi}{6}</m>,
+              <m>\sin(\theta)=-\frac{1}{2}</m></caption> --> <sidebyside> <tabular> <row> <cell><image source="figures/IntroTrigGraphics/TheUnitCircle-33"></image></cell> <cell><image source="figures/IntroTrigGraphics/TheUnitCircle-34"></image></cell> </row> </tabular> </sidebyside> In Quadrant III, one solution is <m>\frac{7\pi}{6}</m>,
               so we capture all Quadrant III solutions by adding integer multiples of <m>2\pi</m>:
               <m>\theta = \frac{7\pi}{6} + 2\pi k</m>.
               In Quadrant IV, one solution is
@@ -779,7 +779,7 @@
               The angles with <m>\cos(\theta) = 0</m> are quadrantal angles whose terminal sides,
               when plotted in standard position,
               lie along the <m>y</m>-axis. <!-- <caption>Angles with
-              <m>\cos(\theta)=0</m></caption> --> <sidebyside> <tabular> <row> <cell><img src="figures/IntroTrigGraphics/TheUnitCircle-35"/></cell> <cell><img src="figures/IntroTrigGraphics/TheUnitCircle-36"/></cell> </row> </tabular> </sidebyside> While,
+              <m>\cos(\theta)=0</m></caption> --> <sidebyside> <tabular> <row> <cell><image source="figures/IntroTrigGraphics/TheUnitCircle-35"></image></cell> <cell><image source="figures/IntroTrigGraphics/TheUnitCircle-36"></image></cell> </row> </tabular> </sidebyside> While,
               technically speaking,
               <m>\frac{\pi}{2}</m> isn't a reference angle we can nonetheless use it to find our answers.
               If we follow the procedure set forth in the previous examples,
@@ -916,7 +916,7 @@
                 with <m>x = 4</m> and <m>y = -2</m>,
                 we find <m>r = \sqrt{(4)^2 + (-2)^2} = \sqrt{20} = 2 \sqrt{5}</m> so that
                 <m>\cos(\theta) = \frac{x}{r} = \frac{4}{2 \sqrt{5}} = \frac{2 \sqrt{5}}{5}</m> and <m>\sin(\theta) = \frac{y}{r} = \frac{-2}{2 \sqrt{5}} = -\frac{\sqrt{5}}{5}</m>:
-                see <xref ref="fig_circle25">Figure</xref>. <figure xml:id="fig_circle25"> <caption>The terminal side of <m>\theta</m> contains <m>Q(4,-2)</m></caption> <img src="figures/IntroTrigGraphics/TheUnitCircle-39"/> </figure>
+                see <xref ref="fig_circle25">Figure</xref>. <figure xml:id="fig_circle25"> <caption>The terminal side of <m>\theta</m> contains <m>Q(4,-2)</m></caption> <image source="figures/IntroTrigGraphics/TheUnitCircle-39"></image> </figure>
               </p>
             </li>
 
@@ -927,7 +927,7 @@
                 Viewing the Equator as the <m>x</m>-axis,
                 the value we seek is the <m>x</m>-coordinate of the point <m>Q(x,y)</m> indicated in <xref ref="fig_circle26">Figure</xref>
                 <figure xml:id="fig_circle26"> <caption>A point on the Earth at
-                <m>41.628^\circ</m>N</caption> <img src="figures/IntroTrigGraphics/TheUnitCircle-40"/> </figure> Using <xref ref="cosinesinecircle">Theorem</xref>,
+                <m>41.628^\circ</m>N</caption> <image source="figures/IntroTrigGraphics/TheUnitCircle-40"></image> </figure> Using <xref ref="cosinesinecircle">Theorem</xref>,
                 we get <m>x = 3960 \cos\left(41.628^{\circ}\right)</m>.
                 Using a calculator in <q>degree</q> mode,
                 we find <m>3960 \cos\left(41.628^{\circ}\right) \approx 2960</m>.
@@ -1020,13 +1020,13 @@
       <caption>Relating triangular and circular trigonometry</caption>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/TheUnitCircle-42"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/TheUnitCircle-42"></image></cell>
         </row>
         <row>
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/TheUnitCircle-43"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/TheUnitCircle-43"></image></cell>
         </row>
       </tabular>
     </table>
@@ -1062,7 +1062,7 @@
 
         <figure xml:id="fig_tritrig2">
           <caption>The triangle for <xref ref="righttriangleex">Example</xref></caption>
-          <img src="figures/IntroTrigGraphics/TheUnitCircle-44"/>
+          <image source="figures/IntroTrigGraphics/TheUnitCircle-44"></image>
         </figure>
       </statement>
       <solution>
@@ -1093,7 +1093,7 @@
 
         <figure xml:id="fig_tritrig3">
           <caption>The completed triangle for <xref ref="righttriangleex">Example</xref></caption>
-          <img src="figures/IntroTrigGraphics/TheUnitCircle-45"/>
+          <image source="figures/IntroTrigGraphics/TheUnitCircle-45"></image>
         </figure>
       </solution>
     </example>
@@ -1135,13 +1135,13 @@
       <caption>Defining <m>\cos(t)</m> and <m>\sin(t)</m> as functions of a real variable</caption>
       <tabular>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/TheUnitCircle-46"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/TheUnitCircle-46"></image></cell>
         </row>
         <row>
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/IntroTrigGraphics/TheUnitCircle-47"/></cell>
+          <cell><image source="figures/IntroTrigGraphics/TheUnitCircle-47"></image></cell>
         </row>
       </tabular>
     </table>
@@ -1934,7 +1934,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TheUnitCircle-48"/>
+          <image source="figures/IntroTrigGraphics/TheUnitCircle-48"></image>
         </p>
       </statement>
       <answer>
@@ -1952,7 +1952,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TheUnitCircle-49"/>
+          <image source="figures/IntroTrigGraphics/TheUnitCircle-49"></image>
         </p>
       </statement>
       <answer>
@@ -1968,7 +1968,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TheUnitCircle-50"/>
+          <image source="figures/IntroTrigGraphics/TheUnitCircle-50"></image>
         </p>
       </statement>
       <answer>
@@ -1986,7 +1986,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TheUnitCircle-48"/>
+          <image source="figures/IntroTrigGraphics/TheUnitCircle-48"></image>
         </p>
       </statement>
       <answer>

--- a/ptx/Transformations.ptx
+++ b/ptx/Transformations.ptx
@@ -17,7 +17,7 @@
 
     <figure xml:id="fig_tran1">
       <caption>The graph of a function <m>f</m></caption>
-      <img src="figures/RelationsandFunctionsGraphics/Transformations-1"/>
+      <image source="figures/RelationsandFunctionsGraphics/Transformations-1"></image>
     </figure>
 
     <p>
@@ -76,11 +76,11 @@
     <sidebyside>
       <tabular>
         <row>
-          <cell><img src="figures/RelationsandFunctionsGraphics/Transformations-2"/></cell>
+          <cell><image source="figures/RelationsandFunctionsGraphics/Transformations-2"></image></cell>
           <cell></cell>
           <cell><m>\stackrel{\stackrel{\mbox{\scriptsize shift up <m>2</m> units} }{\xrightarrow{\hspace{1in}}}}{\mbox{ \scriptsize add <m>2</m> to each <m>y</m>-coordinate} }</m></cell>
           <cell></cell>
-          <cell><img src="figures/RelationsandFunctionsGraphics/Transformations-3"/></cell>
+          <cell><image source="figures/RelationsandFunctionsGraphics/Transformations-3"></image></cell>
         </row>
         <row>
           <cell><m>y=f(x)</m></cell>
@@ -228,11 +228,11 @@
     <sidebyside>
       <tabular>
         <row>
-          <cell><img src="figures/RelationsandFunctionsGraphics/Transformations-4"/></cell>
+          <cell><image source="figures/RelationsandFunctionsGraphics/Transformations-4"></image></cell>
           <cell></cell>
           <cell><m>\stackrel{\stackrel{\mbox{\scriptsize shift left <m>2</m> units} }{\xrightarrow{\hspace{1in}}}}{\mbox{ \scriptsize subtract <m>2</m> from each <m>x</m>-coordinate} }</m></cell>
           <cell></cell>
-          <cell><img src="figures/RelationsandFunctionsGraphics/Transformations-5"/></cell>
+          <cell><image source="figures/RelationsandFunctionsGraphics/Transformations-5"></image></cell>
         </row>
         <row>
           <cell><m>y=f(x)</m></cell>
@@ -338,7 +338,7 @@
               <m>[0,\infty)</m> and the range of <m>f</m> is also <m>[0, \infty)</m>.
               The original function is plotted in <xref ref="fig_origf">Figure</xref>
               <table xml:id="fig_origf"> <caption>The graph
-              <m>y=f(x)=\sqrt{x}</m></caption> <tabular> <row bottom="minor"> <cell></cell> <cell></cell> <cell></cell> </row> <row> <cell><m>x</m></cell> <cell><m>f(x)</m></cell> <cell><m>(x,f(x))</m></cell> </row> <row bottom="minor"> <cell></cell> <cell></cell> <cell></cell> </row> <row> <cell>0</cell> <cell>0</cell> <cell><m>(0,0)</m></cell> </row> <row bottom="minor"> <cell></cell> <cell></cell> <cell></cell> </row> <row> <cell>1</cell> <cell>1</cell> <cell><m>(1,1)</m></cell> </row> <row bottom="minor"> <cell></cell> <cell></cell> <cell></cell> </row> <row> <cell>4</cell> <cell>2</cell> <cell><m>(4,2)</m></cell> </row> <row bottom="minor"> <cell></cell> <cell></cell> <cell></cell> </row> </tabular> <img src="figures/RelationsandFunctionsGraphics/Transformations-6"/> </table>
+              <m>y=f(x)=\sqrt{x}</m></caption> <tabular> <row bottom="minor"> <cell></cell> <cell></cell> <cell></cell> </row> <row> <cell><m>x</m></cell> <cell><m>f(x)</m></cell> <cell><m>(x,f(x))</m></cell> </row> <row bottom="minor"> <cell></cell> <cell></cell> <cell></cell> </row> <row> <cell>0</cell> <cell>0</cell> <cell><m>(0,0)</m></cell> </row> <row bottom="minor"> <cell></cell> <cell></cell> <cell></cell> </row> <row> <cell>1</cell> <cell>1</cell> <cell><m>(1,1)</m></cell> </row> <row bottom="minor"> <cell></cell> <cell></cell> <cell></cell> </row> <row> <cell>4</cell> <cell>2</cell> <cell><m>(4,2)</m></cell> </row> <row bottom="minor"> <cell></cell> <cell></cell> <cell></cell> </row> </tabular> <image source="figures/RelationsandFunctionsGraphics/Transformations-6"></image> </table>
             </p>
           </li>
 
@@ -362,7 +362,7 @@
               We confirm the domain of <m>g</m> is
               <m>[0, \infty)</m> and find the range of <m>g</m> to be <m>[-1, \infty)</m>.
               The graph of <m>g</m> is given in <xref ref="fig_transeg1-1">Figure</xref>. <figure xml:id="fig_transeg1-1"> <caption>Graphing
-              <m>g(x)=\sqrt{x}-1</m></caption> <img src="figures/RelationsandFunctionsGraphics/Transformations-8"/> </figure>
+              <m>g(x)=\sqrt{x}-1</m></caption> <image source="figures/RelationsandFunctionsGraphics/Transformations-8"></image> </figure>
             </p>
           </li>
 
@@ -378,7 +378,7 @@
               We add <m>1</m> to the <m>x</m>-coordinates of the points on the graph of <m>f</m> and get the result below.
               The graph reaffirms that the domain of <m>j</m> is <m>[1,\infty)</m> and tells us that the range of <m>j</m> is
               <m>[0,\infty)</m>. <figure xml:id="fig_transeg1-2"> <caption>Graphing
-              <m>j(x)=\sqrt{x}-1</m></caption> <img src="figures/RelationsandFunctionsGraphics/Transformations-10"/> </figure>
+              <m>j(x)=\sqrt{x}-1</m></caption> <image source="figures/RelationsandFunctionsGraphics/Transformations-10"></image> </figure>
             </p>
           </li>
 
@@ -400,14 +400,14 @@
               <xref ref="hshifts">Theorem</xref>
               tells us that the graph of
               <m>y=m_{1}(x)</m> is the graph of <m>f</m> shifted to the left <m>3</m> units.
-              Hence, we subtract <m>3</m> from each of the <m>x</m>-coordinates of the points on the graph of <m>f</m>. <figure xml:id="fig_transeg1-3"> <caption>Graphing <m>m_1(x)=\sqrt{x+3}</m></caption> <img src="figures/RelationsandFunctionsGraphics/Transformations-12"/> </figure> Since
+              Hence, we subtract <m>3</m> from each of the <m>x</m>-coordinates of the points on the graph of <m>f</m>. <figure xml:id="fig_transeg1-3"> <caption>Graphing <m>m_1(x)=\sqrt{x+3}</m></caption> <image source="figures/RelationsandFunctionsGraphics/Transformations-12"></image> </figure> Since
               <m>m(x) = f(x+3)-2</m> and <m>f(x+3) = m_{1}(x)</m>,
               we have <m>m(x) = m_{1}(x) - 2</m>.
               We can apply <xref ref="vshifts">Theorem</xref>
               and obtain the graph of <m>m</m> by subtracting <m>2</m> from the <m>y</m>-coordinates of each of the points on the graph of <m>m_{1}(x)</m>.
               The graph verifies that the domain of <m>m</m> is <m>[-3, \infty)</m> and we find the range of <m>m</m> to be
               <m>[-2, \infty)</m>. <figure xml:id="fig_transeg1-4"> <caption>Graphing
-              <m>m(x)=\sqrt{x+3}-2</m></caption> <img src="figures/RelationsandFunctionsGraphics/Transformations-14"/> </figure>
+              <m>m(x)=\sqrt{x+3}-2</m></caption> <image source="figures/RelationsandFunctionsGraphics/Transformations-14"></image> </figure>
             </p>
           </li>
         </ol>
@@ -483,11 +483,11 @@
     <sidebyside>
       <tabular>
         <row>
-          <cell><img src="figures/RelationsandFunctionsGraphics/Transformations-15"/></cell>
+          <cell><image source="figures/RelationsandFunctionsGraphics/Transformations-15"></image></cell>
           <cell></cell>
           <cell><m>\stackrel{\stackrel{\mbox{\scriptsize reflect across <m>x</m>-axis} }{\xrightarrow{\hspace{1in}}}}{\mbox{ \scriptsize multiply each <m>y</m>-coordinate by <m>-1</m>} }</m></cell>
           <cell></cell>
-          <cell><img src="figures/RelationsandFunctionsGraphics/Transformations-16"/></cell>
+          <cell><image source="figures/RelationsandFunctionsGraphics/Transformations-16"></image></cell>
         </row>
         <row>
           <cell><m>y=f(x)</m></cell>
@@ -510,11 +510,11 @@
     <sidebyside>
       <tabular>
         <row>
-          <cell><img src="figures/RelationsandFunctionsGraphics/Transformations-17"/></cell>
+          <cell><image source="figures/RelationsandFunctionsGraphics/Transformations-17"></image></cell>
           <cell></cell>
           <cell><m>\stackrel{\stackrel{\mbox{\scriptsize reflect across <m>y</m>-axis} }{\xrightarrow{\hspace{1in}}}}{\mbox{ \scriptsize multiply each <m>x</m>-coordinate by <m>-1</m>} }</m></cell>
           <cell></cell>
-          <cell><img src="figures/RelationsandFunctionsGraphics/Transformations-18"/></cell>
+          <cell><image source="figures/RelationsandFunctionsGraphics/Transformations-18"></image></cell>
         </row>
         <row>
           <cell><m>y=f(x)</m></cell>
@@ -543,7 +543,7 @@
 
         <figure xml:id="fig_sqrtagain">
           <caption>The graph <m>y=f(x)</m> from <xref ref="transformationex1">Example</xref></caption>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-19"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-19"></image>
         </figure>
 
         <ol>
@@ -591,10 +591,10 @@
                 and <m>(-4,2)</m>, respectively.
                 Graphically, we see that the domain of <m>g</m> is
                 <m>(-\infty, 0]</m> and the range of <m>g</m> is the same as the range of <m>f</m>,
-                namely <m>[0,\infty)</m>. <figure xml:id="fig_reflecteg1"> <caption>Reflecting <m>y=f(x)</m> across the <m>y</m>-axis to obtain the graph of <m>g(x)=\sqrt{-x}</m></caption> <img src="figures/RelationsandFunctionsGraphics/Transformations-20"/> </figure> <figure xml:id="fig_reflecteg2"> <caption>The intermediate function
-          <m>j_1(x)=f(x+3)</m></caption> <img src="figures/RelationsandFunctionsGraphics/Transformations-22"/> </figure> <figure xml:id="fig_reflecteg3"> <caption>Reflecting
+                namely <m>[0,\infty)</m>. <figure xml:id="fig_reflecteg1"> <caption>Reflecting <m>y=f(x)</m> across the <m>y</m>-axis to obtain the graph of <m>g(x)=\sqrt{-x}</m></caption> <image source="figures/RelationsandFunctionsGraphics/Transformations-20"></image> </figure> <figure xml:id="fig_reflecteg2"> <caption>The intermediate function
+          <m>j_1(x)=f(x+3)</m></caption> <image source="figures/RelationsandFunctionsGraphics/Transformations-22"></image> </figure> <figure xml:id="fig_reflecteg3"> <caption>Reflecting
           <m>y=j_1(x)</m> across the <m>y</m>-axis to obtain the graph of
-                <m>j(x)=\sqrt{3-x}</m></caption> <img src="figures/RelationsandFunctionsGraphics/Transformations-24"/> </figure> If we had done the reflection first,
+                <m>j(x)=\sqrt{3-x}</m></caption> <image source="figures/RelationsandFunctionsGraphics/Transformations-24"></image> </figure> If we had done the reflection first,
                 then <m>j_{1}(x) = f(-x)</m>.
                 Following this by a shift left would give us
                 <m>j(x) = j_{1}(x+3) = f(-(x+3)) = f(-x-3) = \sqrt{-x-3}</m> which isn't what we want.
@@ -670,7 +670,7 @@
                 If we define an intermediate function
                 <m>m_{1}(x) = -f(x)</m> to take care of the reflection,
                 we get the graph in <xref ref="fig_reflecteg4">Figure</xref>. <figure xml:id="fig_reflecteg4"> <caption>Reflecting <m>y=f(x)</m> across the <m>x</m>-axis to obtain the graph of
-                <m>m_1(x)=-\sqrt{x}</m></caption> <img src="figures/RelationsandFunctionsGraphics/Transformations-26"/> </figure> To shift the graph of <m>m_{1}</m> up <m>3</m> units,
+                <m>m_1(x)=-\sqrt{x}</m></caption> <image source="figures/RelationsandFunctionsGraphics/Transformations-26"></image> </figure> To shift the graph of <m>m_{1}</m> up <m>3</m> units,
                 we set <m>m(x) = m_{1}(x)+3</m>.
                 Since <m>m_{1}(x) = -f(x)</m>,
                 when we put it all together,
@@ -678,7 +678,7 @@
                 We see from the graph that the range of <m>m</m> is
           <m>(-\infty, 3]</m>. <figure xml:id="fig_reflecteg5"> <caption>Shifting
                 <m>y=m_1(x)</m> up by three units to obtain the graph of
-                <m>m(x)=3-\sqrt{x}</m></caption> <img src="figures/RelationsandFunctionsGraphics/Transformations-28"/> </figure>
+                <m>m(x)=3-\sqrt{x}</m></caption> <image source="figures/RelationsandFunctionsGraphics/Transformations-28"></image> </figure>
               </p>
             </li>
           </ol>
@@ -799,7 +799,7 @@
       <caption>Graphing <m>g(x) = 2f(x)</m></caption>
       <tabular>
         <row>
-          <cell><img src="figures/RelationsandFunctionsGraphics/Transformations-29"/></cell>
+          <cell><image source="figures/RelationsandFunctionsGraphics/Transformations-29"></image></cell>
         </row>
         <row>
           <cell><m>y=f(x)</m></cell>
@@ -808,7 +808,7 @@
           <cell></cell>
         </row>
         <row>
-          <cell><img src="figures/RelationsandFunctionsGraphics/Transformations-31"/></cell>
+          <cell><image source="figures/RelationsandFunctionsGraphics/Transformations-31"></image></cell>
         </row>
         <row>
           <cell><m>y=2f(x)=g(x)</m></cell>
@@ -876,7 +876,7 @@
 
     <figure xml:id="fig_scalefhalf">
       <caption>Vertical scaling by  <m>\frac{1}{2}</m></caption>
-      <img src="figures/RelationsandFunctionsGraphics/Transformations-33"/>
+      <image source="figures/RelationsandFunctionsGraphics/Transformations-33"></image>
     </figure>
 
     <figure xml:id="fig_graphscale">
@@ -884,7 +884,7 @@
     <sidebyside>
       <figure>
         <caption>The graph <m>y=f(x)</m> from <xref ref="fig_tran1">Figure</xref></caption>
-        <img src="figures/RelationsandFunctionsGraphics/Transformations-34"/>
+        <image source="figures/RelationsandFunctionsGraphics/Transformations-34"></image>
       </figure>
 
       <figure>
@@ -893,7 +893,7 @@
 
       <figure>
         <caption>The graph <m>y=h(x)=f(\frac{1}{2}x)</m></caption>
-        <img src="figures/RelationsandFunctionsGraphics/Transformations-37"/>
+        <image source="figures/RelationsandFunctionsGraphics/Transformations-37"></image>
       </figure>
     </sidebyside>
     </figure>
@@ -1047,17 +1047,17 @@
 
         <figure xml:id="fig_sqrtoncemore">
           <caption>The graph <m>y=\sqrt{x}</m></caption>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-40"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-40"></image>
         </figure>
 
         <figure xml:id="fig_scaleeg1">
           <caption>The graph <m>y=g(x) = 3\sqrt{x}</m></caption>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-39"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-39"></image>
         </figure>
 
         <figure xml:id="fig_scaleeg2">
           <caption>The graph <m>y=j(x) = \sqrt{9x}</m></caption>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-41"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-41"></image>
         </figure>
 
         <ol>
@@ -1137,13 +1137,13 @@
                 <m>m_{1}(x) = f\left(x+ \frac{3}{2}\right) = \sqrt{x+\frac{3}{2}}</m> will shift the graph of <m>f</m> to the left <m>\frac{3}{2}</m> units:
                 see <xref ref="fig_scaleeg3">Figure</xref>
                 <figure xml:id="fig_scaleeg3"> <caption>The graph
-                <m>y=m_1(x) = f(x+\frac{3}{2})=\sqrt{x+\frac{3}{2}}</m></caption> <img src="figures/RelationsandFunctionsGraphics/Transformations-43"/> </figure> Next,
+                <m>y=m_1(x) = f(x+\frac{3}{2})=\sqrt{x+\frac{3}{2}}</m></caption> <image source="figures/RelationsandFunctionsGraphics/Transformations-43"></image> </figure> Next,
                 <m>m_{2}(x) = m_{1}\left(\frac{1}{2} x\right) = \sqrt{\frac{1}{2} x + \frac{3}{2}}</m> will,
                 according to <xref ref="hscalings">Theorem</xref>,
                 horizontally stretch the graph of <m>m_{1}</m> by a factor of <m>2</m>:
                 see <xref ref="fig_scaleeg4">Figure</xref>
                 <figure xml:id="fig_scaleeg4"> <caption>The graph
-                <m>y=m_2(x) = m_1(\frac{1}{2}x) = \sqrt{\frac{1}{2}x+\frac{3}{2}}</m></caption> <img src="figures/RelationsandFunctionsGraphics/Transformations-45"/> </figure> We now examine what's happening to the outputs.
+                <m>y=m_2(x) = m_1(\frac{1}{2}x) = \sqrt{\frac{1}{2}x+\frac{3}{2}}</m></caption> <image source="figures/RelationsandFunctionsGraphics/Transformations-45"></image> </figure> We now examine what's happening to the outputs.
                 From <m>m(x) = - f\left(\frac{1}{2} x + \frac{3}{2}\right) + 1</m>,
                 we see that the output from <m>f</m> is being multiplied by <m>-1</m> (a reflection about the <m>x</m>-axis) and then a <m>1</m> is added (a vertical shift up <m>1</m>).
                 As before,
@@ -1156,13 +1156,13 @@
                 is first multiplied by <m>-1</m> then the <m>1</m> is added meaning we first reflect the graph about the <m>x</m>-axis then shift up <m>1</m>.
                 <xref ref="reflections">Theorem</xref>
                 tells us <m>m_{3}(x) = - m_{2}(x)</m> will handle the reflection. <figure xml:id="fig_scaleeg5"> <caption>The graph
-                <m>y=m_3(x) = -m_2(x)=-\sqrt{\frac{1}{2}x+\frac{3}{2}}</m></caption> <img src="figures/RelationsandFunctionsGraphics/Transformations-47"/> </figure> Finally,
+                <m>y=m_3(x) = -m_2(x)=-\sqrt{\frac{1}{2}x+\frac{3}{2}}</m></caption> <image source="figures/RelationsandFunctionsGraphics/Transformations-47"></image> </figure> Finally,
                 to handle the vertical shift,
                 <xref ref="vshifts">Theorem</xref>
                 gives <m>m(x) = m_{3}(x) +1</m>,
                 and we see that the range of <m>m</m> is <m>(-\infty,1]</m>.
                 The graph of <m>m</m> is given in <xref ref="fig_scaleeg6">Figure</xref>. <figure xml:id="fig_scaleeg6"> <caption>The graph
-                <m>y=m(x) = m_3(x)+1=-\sqrt{\frac{1}{2}x+\frac{3}{2}}</m></caption> <img src="figures/RelationsandFunctionsGraphics/Transformations-49"/> </figure>
+                <m>y=m(x) = m_3(x)+1=-\sqrt{\frac{1}{2}x+\frac{3}{2}}</m></caption> <image source="figures/RelationsandFunctionsGraphics/Transformations-49"></image> </figure>
               </p>
             </li>
           </ol>
@@ -1282,7 +1282,7 @@
 
         <figure xml:id="fig_gentransorig">
           <caption>The graph <m>y=f(x)</m> for <xref ref="transformationeg4">Example</xref></caption>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-50"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-50"></image>
         </figure>
       </statement>
       <solution xml:id="fig_gentransresult">
@@ -1479,8 +1479,8 @@
         <sidebyside>
           <tabular>
             <row>
-              <cell><img src="figures/RelationsandFunctionsGraphics/Transformations-51"/></cell>
-              <cell><img src="figures/RelationsandFunctionsGraphics/Transformations-52"/></cell>
+              <cell><image source="figures/RelationsandFunctionsGraphics/Transformations-51"></image></cell>
+              <cell><image source="figures/RelationsandFunctionsGraphics/Transformations-52"></image></cell>
             </row>
             <row>
               <cell><m>y=f(x)</m></cell>
@@ -1556,7 +1556,7 @@
         <sidebyside>
           <figure>
             <caption><m>y=f(x)=x^2</m></caption>
-            <img src="figures/RelationsandFunctionsGraphics/Transformations01"/>
+            <image source="figures/RelationsandFunctionsGraphics/Transformations01"></image>
           </figure>
 
           <figure>
@@ -1822,7 +1822,7 @@
     </p>
 
     <p>
-      <img src="figures/RelationsandFunctionsGraphics/Transformations-53"/>
+      <image source="figures/RelationsandFunctionsGraphics/Transformations-53"></image>
     </p>
     <exercise>
       <statement>
@@ -1836,7 +1836,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-59"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-59"></image>
         </p>
       </answer>
     </exercise>
@@ -1852,7 +1852,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-60"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-60"></image>
         </p>
       </answer>
     </exercise>
@@ -1868,7 +1868,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-61"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-61"></image>
         </p>
       </answer>
     </exercise>
@@ -1884,7 +1884,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-62"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-62"></image>
         </p>
       </answer>
     </exercise>
@@ -1900,7 +1900,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-63"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-63"></image>
         </p>
       </answer>
     </exercise>
@@ -1916,7 +1916,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-64"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-64"></image>
         </p>
       </answer>
     </exercise>
@@ -1932,7 +1932,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-65"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-65"></image>
         </p>
       </answer>
     </exercise>
@@ -1948,7 +1948,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-66"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-66"></image>
         </p>
       </answer>
     </exercise>
@@ -1964,7 +1964,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-67"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-67"></image>
         </p>
       </answer>
     </exercise>
@@ -1976,7 +1976,7 @@
     </p>
 
     <p>
-      <img src="figures/RelationsandFunctionsGraphics/Transformations-54"/>
+      <image source="figures/RelationsandFunctionsGraphics/Transformations-54"></image>
     </p>
     <exercise>
       <statement>
@@ -1990,7 +1990,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-68"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-68"></image>
         </p>
       </answer>
     </exercise>
@@ -2006,7 +2006,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-69"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-69"></image>
         </p>
       </answer>
     </exercise>
@@ -2022,7 +2022,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-70"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-70"></image>
         </p>
       </answer>
     </exercise>
@@ -2038,7 +2038,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-71"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-71"></image>
         </p>
       </answer>
     </exercise>
@@ -2054,7 +2054,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-72"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-72"></image>
         </p>
       </answer>
     </exercise>
@@ -2070,7 +2070,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-73"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-73"></image>
         </p>
       </answer>
     </exercise>
@@ -2086,7 +2086,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-74"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-74"></image>
         </p>
       </answer>
     </exercise>
@@ -2102,7 +2102,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-75"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-75"></image>
         </p>
       </answer>
     </exercise>
@@ -2118,7 +2118,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-76"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-76"></image>
         </p>
       </answer>
     </exercise>
@@ -2130,7 +2130,7 @@
     </p>
 
     <p>
-      <img src="figures/RelationsandFunctionsGraphics/Transformations-55"/>
+      <image source="figures/RelationsandFunctionsGraphics/Transformations-55"></image>
     </p>
     <exercise>
       <statement>
@@ -2144,7 +2144,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-77"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-77"></image>
         </p>
       </answer>
     </exercise>
@@ -2160,7 +2160,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-78"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-78"></image>
         </p>
       </answer>
     </exercise>
@@ -2176,7 +2176,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-79"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-79"></image>
         </p>
       </answer>
     </exercise>
@@ -2192,7 +2192,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-80"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-80"></image>
         </p>
       </answer>
     </exercise>
@@ -2208,7 +2208,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-81"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-81"></image>
         </p>
       </answer>
     </exercise>
@@ -2224,7 +2224,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-82"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-82"></image>
         </p>
       </answer>
     </exercise>
@@ -2240,7 +2240,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-83"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-83"></image>
         </p>
       </answer>
     </exercise>
@@ -2256,7 +2256,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-84"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-84"></image>
         </p>
       </answer>
     </exercise>
@@ -2272,7 +2272,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-85"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-85"></image>
         </p>
       </answer>
     </exercise>
@@ -2288,7 +2288,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-86"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-86"></image>
         </p>
       </answer>
     </exercise>
@@ -2304,7 +2304,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-87"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-87"></image>
         </p>
       </answer>
     </exercise>
@@ -2320,7 +2320,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-88"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-88"></image>
         </p>
       </answer>
     </exercise>
@@ -2332,7 +2332,7 @@
     </p>
 
     <p>
-      <img src="figures/RelationsandFunctionsGraphics/Transformations-56"/>
+      <image source="figures/RelationsandFunctionsGraphics/Transformations-56"></image>
     </p>
     <exercise>
       <statement>
@@ -2346,7 +2346,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-89"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-89"></image>
         </p>
       </answer>
     </exercise>
@@ -2362,7 +2362,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-90"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-90"></image>
         </p>
       </answer>
     </exercise>
@@ -2378,7 +2378,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-91"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-91"></image>
         </p>
       </answer>
     </exercise>
@@ -2394,7 +2394,7 @@
         </p>
 
         <p>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-92"/>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-92"></image>
         </p>
       </answer>
     </exercise>
@@ -2532,8 +2532,8 @@
         </p>
 
         <figure>
-          <caption><img src="figures/RelationsandFunctionsGraphics/Transformations-58"/></caption>
-          <img src="figures/RelationsandFunctionsGraphics/Transformations-57"/>
+          <caption><image source="figures/RelationsandFunctionsGraphics/Transformations-58"></image></caption>
+          <image source="figures/RelationsandFunctionsGraphics/Transformations-57"></image>
         </figure>
       </statement>
     </exercise>

--- a/ptx/TrigEquIneq.ptx
+++ b/ptx/TrigEquIneq.ptx
@@ -154,7 +154,7 @@
 
                 <figure xml:id="fig_trigeg1-1">
                   <caption>Solving <m>\cos(2x)=-\frac{\sqrt{3}}{2}</m></caption>
-                  <img src="figures/IntroTrigGraphics/TrigEquIneq01"/>
+                  <image source="figures/IntroTrigGraphics/TrigEquIneq01"></image>
                 </figure>
 
               </p>
@@ -208,7 +208,7 @@
 
                 <figure xml:id="fig_trigeg1-2">
                   <caption>Solving <m>\csc\left(\frac{1}{3}x-\pi\right)=\sqrt{2}</m></caption>
-                  <img src="figures/IntroTrigGraphics/TrigEquIneq02"/>
+                  <image source="figures/IntroTrigGraphics/TrigEquIneq02"></image>
                 </figure>
 
               </p>
@@ -237,7 +237,7 @@
 
                 <figure xml:id="fig_trigeg1-3">
                   <caption>Solving <m>\cot(3x)=0</m></caption>
-                  <img src="figures/IntroTrigGraphics/TrigEquIneq03"/>
+                  <image source="figures/IntroTrigGraphics/TrigEquIneq03"></image>
                 </figure>
 
                 <aside>
@@ -308,7 +308,7 @@
 
                 <figure xml:id="fig_trigeg1-4">
                   <caption>Solving <m>\sec^2(x)=4</m></caption>
-                  <img src="figures/IntroTrigGraphics/TrigEquIneq04"/>
+                  <image source="figures/IntroTrigGraphics/TrigEquIneq04"></image>
                 </figure>
 
               </p>
@@ -354,7 +354,7 @@
 
                 <figure xml:id="fig_trigeg1-5">
                   <caption>Solving <m>\tan(\frac{x}{2})=-3</m></caption>
-                  <img src="figures/IntroTrigGraphics/TrigEquIneq05"/>
+                  <image source="figures/IntroTrigGraphics/TrigEquIneq05"></image>
                 </figure>
 
               </p>
@@ -418,7 +418,7 @@
 
                 <figure xml:id="fig_trigeg1-6">
                   <caption>Solving <m>\sin(2x)=0.87</m></caption>
-                  <img src="figures/IntroTrigGraphics/TrigEquIneq06"/>
+                  <image source="figures/IntroTrigGraphics/TrigEquIneq06"></image>
                 </figure>
 
               </p>
@@ -528,12 +528,12 @@
 
                 <figure xml:id="fig_trigeg2-1a">
                   <caption>Solving <m>3\sin^3(x)=\sin^2(x)</m></caption>
-                  <img src="figures/IntroTrigGraphics/TrigEquIneq07"/>
+                  <image source="figures/IntroTrigGraphics/TrigEquIneq07"></image>
                 </figure>
 
                 <figure xml:id="fig_trigeg2-1b">
                   <caption>Zooming in on the first two solutions for <xref ref="TrigEqIdEx1">Example</xref>.1</caption>
-                  <img src="figures/IntroTrigGraphics/TrigEquIneq08"/>
+                  <image source="figures/IntroTrigGraphics/TrigEquIneq08"></image>
                 </figure>
 
               </p>
@@ -574,7 +574,7 @@
 
                 <figure xml:id="fig_trigeg2-2">
                   <caption>Solving <m>\sec^2(x)=\tan(x)+3</m></caption>
-                  <img src="figures/IntroTrigGraphics/TrigEquIneq09"/>
+                  <image source="figures/IntroTrigGraphics/TrigEquIneq09"></image>
                 </figure>
 
               </p>
@@ -613,7 +613,7 @@
 
                 <figure xml:id="fig_trigeg2-3">
                   <caption>Solving <m>\cos(2x)=3\cos(x)-2</m></caption>
-                  <img src="figures/IntroTrigGraphics/TrigEquIneq10"/>
+                  <image source="figures/IntroTrigGraphics/TrigEquIneq10"></image>
                 </figure>
 
               </p>
@@ -651,7 +651,7 @@
 
                 <figure xml:id="fig_trigeg2-4">
                   <caption>Solving <m>\cos(3x)=2-\cos(x)</m></caption>
-                  <img src="figures/IntroTrigGraphics/TrigEquIneq11"/>
+                  <image source="figures/IntroTrigGraphics/TrigEquIneq11"></image>
                 </figure>
 
               </p>
@@ -686,7 +686,7 @@
                 Our plot of the graphs of <m>y = \cos(3x)</m> and
                 <m>y = \cos(5x)</m> in <xref ref="fig_trigeg2-5">Figure</xref>
                 bears this out. <figure xml:id="fig_trigeg2-5"> <caption>Solving
-                <m>\cos(3x)=\cos(5x)</m></caption> <img src="figures/IntroTrigGraphics/TrigEquIneq12"/> </figure>
+                <m>\cos(3x)=\cos(5x)</m></caption> <image source="figures/IntroTrigGraphics/TrigEquIneq12"></image> </figure>
               </p>
             </li>
 
@@ -719,12 +719,12 @@
 
                 <figure xml:id="fig_trigeg2-6">
                   <caption>Solving <m>\sin(2x)-\sqrt{3}\cos(x)</m></caption>
-                  <img src="figures/IntroTrigGraphics/TrigEquIneq13"/>
+                  <image source="figures/IntroTrigGraphics/TrigEquIneq13"></image>
                 </figure>
 
                 <figure xml:id="fig_trigeg2-7">
                   <caption>Solving <m>\sin(x)\cos(\frac{x}{2})+\cos(x)\sin(\frac{x}{2})=1</m></caption>
-                  <img src="figures/IntroTrigGraphics/TrigEquIneq14"/>
+                  <image source="figures/IntroTrigGraphics/TrigEquIneq14"></image>
                 </figure>
 
               </p>
@@ -770,7 +770,7 @@
                 Geometrically, we see in <xref ref="fig_trigeg2-8">Figure</xref>
                 that <m>y = \cos(x) - \sqrt{3} \sin(x)</m> and <m>y = 2</m> intersect just once,
                 supporting our answer. <figure xml:id="fig_trigeg2-8"> <caption>Solving
-                <m>\cos(x)-\sqrt{3}\sin(x)=2</m></caption> <img src="figures/IntroTrigGraphics/TrigEquIneq15"/> </figure>
+                <m>\cos(x)-\sqrt{3}\sin(x)=2</m></caption> <image source="figures/IntroTrigGraphics/TrigEquIneq15"></image> </figure>
               </p>
             </li>
           </ol>
@@ -859,7 +859,7 @@
                 We can confirm our answer graphically by seeing where the graph of
                 <m>y = 2\sin(x)</m> crosses or is below the graph of <m>y = 1</m>:
                 see <xref ref="fig_trigeg3-1">Figure</xref>. <table xml:id="fig_trigeg3-1"> <caption>Solving
-                <m>2\sin(x)\leq 1</m></caption> <tabular> <row> <cell><img src="figures/IntroTrigGraphics/TrigEquIneq_new-1"/></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/IntroTrigGraphics/TrigEquIneq16"/></cell> </row> </tabular> </table>
+                <m>2\sin(x)\leq 1</m></caption> <tabular> <row> <cell><image source="figures/IntroTrigGraphics/TrigEquIneq_new-1"></image></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/IntroTrigGraphics/TrigEquIneq16"></image></cell> </row> </tabular> </table>
               </p>
             </li>
 
@@ -893,7 +893,7 @@
                 We can use GeoGebra to check that the graph of
                 <m>y = \sin(2x)</m> is indeed above the graph of <m>y = \cos(x)</m> on those intervals;
                 see <xref ref="fig_trigeg3-2">Figure</xref>. <table xml:id="fig_trigeg3-2"> <caption>Solving
-                <m>\sin(2x)>\cos(x)</m></caption> <tabular> <row> <cell><img src="figures/IntroTrigGraphics/TrigEquIneq_new-2"/></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/IntroTrigGraphics/TrigEquIneq17"/></cell> </row> </tabular> </table>
+                <m>\sin(2x)>\cos(x)</m></caption> <tabular> <row> <cell><image source="figures/IntroTrigGraphics/TrigEquIneq_new-2"></image></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/IntroTrigGraphics/TrigEquIneq17"></image></cell> </row> </tabular> </table>
               </p>
             </li>
 
@@ -940,7 +940,7 @@
                 when the graph of the former is above
                 (or meets)
                 the graph of the latter. <table xml:id="fig_trigeg3-3"> <caption>Solving
-                <m>\tan(x)\geq 3</m></caption> <tabular> <row> <cell><img src="figures/IntroTrigGraphics/TrigEquIneq_new-3"/></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/IntroTrigGraphics/TrigEquIneq18"/></cell> </row> </tabular> </table>
+                <m>\tan(x)\geq 3</m></caption> <tabular> <row> <cell><image source="figures/IntroTrigGraphics/TrigEquIneq_new-3"></image></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/IntroTrigGraphics/TrigEquIneq18"></image></cell> </row> </tabular> </table>
               </p>
             </li>
           </ol>
@@ -1002,7 +1002,7 @@
                 where we have kept the denominators <m>6</m> throughout to help see the pattern.
                 Graphing the situation on a number line, we have
 
-                <img src="figures/IntroTrigGraphics/TrigEquIneq_new-4"/>
+                <image source="figures/IntroTrigGraphics/TrigEquIneq_new-4"></image>
 
                 Proceeding as we did on <xref ref="extendedinterval">page</xref>
                 in <xref ref="circularfunctionsbeyond">Section</xref>,
@@ -1032,7 +1032,7 @@
                 or  <m>\left\{ x : x \neq \pm \frac{\pi}{3}, \pm \frac{5\pi}{3}, \pm \frac{7\pi}{3}, \pm \frac{11\pi}{3}, \ldots \right\}</m>,
                 so we have
 
-                <img src="figures/IntroTrigGraphics/TrigEquIneq_new-5"/>
+                <image source="figures/IntroTrigGraphics/TrigEquIneq_new-5"></image>
 
                 Unlike the previous example,
                 we have <em>two</em>
@@ -1110,7 +1110,7 @@
                 we get <m>g\left(\frac{\pi}{6}\right) = 1 - \sqrt{3}</m>,
                 and <m>g\left(\frac{\pi}{2}\right) = 1</m>.
 
-                <img src="figures/IntroTrigGraphics/TrigEquIneq_new-6"/>
+                <image source="figures/IntroTrigGraphics/TrigEquIneq_new-6"></image>
 
                 We find <m>g(x) \geq 0</m> on <m>\left[\frac{\pi}{4}, \pi \right)</m>.
                 Adding multiples of the period we get our solution to consist of the intervals  <m>\left[\frac{\pi}{4} + \pi k, \pi + \pi k  \right) = \left[\frac{(4k+1)\pi}{4}, (k+1)\pi \right)</m>.
@@ -1198,7 +1198,7 @@
 
                 <figure xml:id="fig_trigeg4-1">
                   <caption>Solving <m>\arcsin(2x)=\frac{\pi}{3}</m></caption>
-                  <img src="figures/IntroTrigGraphics/TrigEquIneq19"/>
+                  <image source="figures/IntroTrigGraphics/TrigEquIneq19"></image>
                 </figure>
 
               </p>
@@ -1223,7 +1223,7 @@
 
                 <figure xml:id="fig_trigeg4-2">
                   <caption>Solving <m>4\arccos(x)-3\pi=0</m></caption>
-                  <img src="figures/IntroTrigGraphics/TrigEquIneq20"/>
+                  <image source="figures/IntroTrigGraphics/TrigEquIneq20"></image>
                 </figure>
 
               </p>
@@ -1258,7 +1258,7 @@
 
                 <figure xml:id="fig_trigeg4-3">
                   <caption>Solving <m>3\operatorname{arcsec}(2x-1)+\pi=2\pi</m></caption>
-                  <img src="figures/IntroTrigGraphics/TrigEquIneq21"/>
+                  <image source="figures/IntroTrigGraphics/TrigEquIneq21"></image>
                 </figure>
 
               </p>
@@ -1286,7 +1286,7 @@
 
                 <figure xml:id="fig_trigeg4-4">
                   <caption>Solving <m>4\arctan^2(x)-3\pi\arctan(x)-\pi^2=0</m></caption>
-                  <img src="figures/IntroTrigGraphics/TrigEquIneq22"/>
+                  <image source="figures/IntroTrigGraphics/TrigEquIneq22"></image>
                 </figure>
 
               </p>
@@ -1317,7 +1317,7 @@
                 the graph of <m>y = \pi^2-4\arccos^{2}(x)</m> is below <m>y = 0</m>
                 (the <m>x</m>-axis.)
                 <table xml:id="fig_trigeg4-5"> <caption>Solving
-                <m>\pi^2-4\arccos^2(x)\lt 0</m></caption> <tabular> <row> <cell><img src="figures/IntroTrigGraphics/TrigEquIneq_new-7"/></cell> </row> <row> <cell></cell> </row> <row> <cell><img src="figures/IntroTrigGraphics/TrigEquIneq23"/></cell> </row> </tabular> </table>
+                <m>\pi^2-4\arccos^2(x)\lt 0</m></caption> <tabular> <row> <cell><image source="figures/IntroTrigGraphics/TrigEquIneq_new-7"></image></cell> </row> <row> <cell></cell> </row> <row> <cell><image source="figures/IntroTrigGraphics/TrigEquIneq23"></image></cell> </row> </tabular> </table>
               </p>
             </li>
 
@@ -1368,13 +1368,13 @@
                   <caption>Solving <m>4\operatorname{arccot}(3x)>\pi</m></caption>
                   <tabular>
                     <row>
-                      <cell><img src="figures/IntroTrigGraphics/TrigEquIneq_new-8"/></cell>
+                      <cell><image source="figures/IntroTrigGraphics/TrigEquIneq_new-8"></image></cell>
                     </row>
                     <row>
                       <cell></cell>
                     </row>
                     <row>
-                      <cell><img src="figures/IntroTrigGraphics/TrigEquIneq24"/></cell>
+                      <cell><image source="figures/IntroTrigGraphics/TrigEquIneq24"></image></cell>
                     </row>
                   </tabular>
                 </table>

--- a/ptx/TrigGraphs.ptx
+++ b/ptx/TrigGraphs.ptx
@@ -324,7 +324,7 @@
         <cell></cell>
       </row>
       <row>
-        <cell><img src="figures/IntroTrigGraphics/TrigGraphs-1"/></cell>
+        <cell><image source="figures/IntroTrigGraphics/TrigGraphs-1"></image></cell>
       </row>
       <row>
         <cell>The <q>fundamental cycle</q> of <m>y = \cos(x)</m>.</cell>
@@ -482,7 +482,7 @@
         <cell></cell>
       </row>
       <row>
-        <cell><img src="figures/IntroTrigGraphics/TrigGraphs-3"/></cell>
+        <cell><image source="figures/IntroTrigGraphics/TrigGraphs-3"></image></cell>
       </row>
       <row>
         <cell>The <q>fundamental cycle</q> of <m>y = \sin(x)</m></cell>
@@ -635,7 +635,7 @@
                       \end{array}
                     </me>
                     &amp; 
-                    <img src="figures/IntroTrigGraphics/TrigGraphs-5"/>
+                    <image source="figures/IntroTrigGraphics/TrigGraphs-5"></image>
                   </tabular>
                 </sidebyside>
                 One cycle is graphed on <m>[1,5]</m> so the period is the length of that interval which is <m>4</m>.
@@ -680,7 +680,7 @@
                       \end{array}
                     </me>
                     &amp; 
-                    <img src="figures/IntroTrigGraphics/TrigGraphs-6"/>
+                    <image source="figures/IntroTrigGraphics/TrigGraphs-6"></image>
                   </tabular>
                 </sidebyside>
                 <figure xml:id="fig_triggraph4">
@@ -748,7 +748,7 @@
     </aside>
     <figure xml:id="fig_triggraph5">
       <caption>Properties of sinusoids</caption>
-      <img src="figures/IntroTrigGraphics/TrigGraphs-7"/>
+      <image source="figures/IntroTrigGraphics/TrigGraphs-7"></image>
     </figure>
 
     <p>
@@ -906,7 +906,7 @@
 
         <figure xml:id="fig_triggraph6">
           <caption>One cycle of <m>y=f(x)</m> in <xref ref="fitsinusoidtodata1">Example</xref></caption>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-8"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-8"></image>
         </figure>
 
         <ol>
@@ -961,7 +961,7 @@
               Taking the phase shift to be <m>\frac{7}{2}</m>,
               we get <m>-\frac{\phi}{\omega} = \frac{7}{2}</m>,
               or <m>\phi = -\frac{7}{2} \omega = -\frac{7}{2}\left(\frac{\pi}{3}\right) = -\frac{7\pi}{6}</m>.
-              Hence, our answer is <m>S(x) = 2 \sin\left(\frac{\pi}{3} x - \frac{7\pi}{6}\right) + \frac{1}{2}</m>. <!-- <caption>Extending the graph of <m>y=f(x)</m></caption> --> <sidebyside> <img src="figures/IntroTrigGraphics/TrigGraphs-9"/> </sidebyside>
+              Hence, our answer is <m>S(x) = 2 \sin\left(\frac{\pi}{3} x - \frac{7\pi}{6}\right) + \frac{1}{2}</m>. <!-- <caption>Extending the graph of <m>y=f(x)</m></caption> --> <sidebyside> <image source="figures/IntroTrigGraphics/TrigGraphs-9"></image> </sidebyside>
             </p>
             </li>
           </ol>
@@ -1195,7 +1195,7 @@
           \end{array}
         </me>
         &amp;
-        <img src="figures/IntroTrigGraphics/TrigGraphs-10"/>
+        <image source="figures/IntroTrigGraphics/TrigGraphs-10"></image>
       </tabular>
     </sidebyside>
     <aside>
@@ -1259,7 +1259,7 @@
           \end{array}
         </me>
         &amp;
-        <img src="figures/IntroTrigGraphics/TrigGraphs-12"/>
+        <image source="figures/IntroTrigGraphics/TrigGraphs-12"></image>
       </tabular>
     </sidebyside>
     <p>
@@ -1474,7 +1474,7 @@
                       \end{array}
                     </me>
                     &amp; 
-                    <img src="figures/IntroTrigGraphics/TrigGraphs-14"/>
+                    <image source="figures/IntroTrigGraphics/TrigGraphs-14"></image>
                   </tabular>
                 </sidebyside>
               </p>
@@ -1536,7 +1536,7 @@
                       \end{array}
                     </me>
                     &amp; 
-                    <img src="figures/IntroTrigGraphics/TrigGraphs-15"/>
+                    <image source="figures/IntroTrigGraphics/TrigGraphs-15"></image>
                   </tabular>
                 </sidebyside>
               </p>
@@ -1606,7 +1606,7 @@
           \end{array}
         </me>
         &amp; 
-        <img src="figures/IntroTrigGraphics/TrigGraphs-16"/>
+        <image source="figures/IntroTrigGraphics/TrigGraphs-16"></image>
       </tabular>
     </sidebyside>
 
@@ -1676,7 +1676,7 @@
           \end{array}
         </me>
         &amp; 
-        <img src="figures/IntroTrigGraphics/TrigGraphs-18"/>
+        <image source="figures/IntroTrigGraphics/TrigGraphs-18"></image>
       </tabular>
     </sidebyside>
     <p>
@@ -1876,7 +1876,7 @@
                       \end{array}
                     </me>
                     &amp; 
-                    <img src="figures/IntroTrigGraphics/TrigGraphs-20"/>
+                    <image source="figures/IntroTrigGraphics/TrigGraphs-20"></image>
                   </tabular>
                 </sidebyside>
                 We see that the period is <m>\pi - (-\pi) = 2\pi</m>.
@@ -1940,7 +1940,7 @@
                       \end{array}
                     </me>
                     &amp; 
-                    <img src="figures/IntroTrigGraphics/TrigGraphs-21"/>
+                    <image source="figures/IntroTrigGraphics/TrigGraphs-21"></image>
                   </tabular>
                 </sidebyside>
                 We find the period to be <m>0 - (-2) = 2</m>.
@@ -1996,7 +1996,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-22"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-22"></image>
         </p>
       </answer>
     </exercise>
@@ -2028,7 +2028,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-23"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-23"></image>
         </p>
       </answer>
     </exercise>
@@ -2060,7 +2060,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-24"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-24"></image>
         </p>
       </answer>
     </exercise>
@@ -2092,7 +2092,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-25"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-25"></image>
         </p>
       </answer>
     </exercise>
@@ -2124,7 +2124,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-26"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-26"></image>
         </p>
       </answer>
     </exercise>
@@ -2156,7 +2156,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-27"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-27"></image>
         </p>
       </answer>
     </exercise>
@@ -2188,7 +2188,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-28"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-28"></image>
         </p>
       </answer>
     </exercise>
@@ -2220,7 +2220,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-29"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-29"></image>
         </p>
       </answer>
     </exercise>
@@ -2255,7 +2255,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-30"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-30"></image>
         </p>
       </answer>
     </exercise>
@@ -2290,7 +2290,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-31"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-31"></image>
         </p>
       </answer>
     </exercise>
@@ -2322,7 +2322,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-32"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-32"></image>
         </p>
       </answer>
     </exercise>
@@ -2357,7 +2357,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-33"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-33"></image>
         </p>
       </answer>
     </exercise>
@@ -2381,7 +2381,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-34"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-34"></image>
         </p>
       </answer>
     </exercise>
@@ -2401,7 +2401,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-35"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-35"></image>
         </p>
       </answer>
     </exercise>
@@ -2433,7 +2433,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-36"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-36"></image>
         </p>
       </answer>
     </exercise>
@@ -2457,7 +2457,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-37"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-37"></image>
         </p>
       </answer>
     </exercise>
@@ -2481,7 +2481,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-38"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-38"></image>
         </p>
       </answer>
     </exercise>
@@ -2505,7 +2505,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-39"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-39"></image>
         </p>
       </answer>
     </exercise>
@@ -2529,7 +2529,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-40"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-40"></image>
         </p>
       </answer>
     </exercise>
@@ -2553,7 +2553,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-41"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-41"></image>
         </p>
       </answer>
     </exercise>
@@ -2577,7 +2577,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-42"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-42"></image>
         </p>
       </answer>
     </exercise>
@@ -2597,7 +2597,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-43"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-43"></image>
         </p>
       </answer>
     </exercise>
@@ -2617,7 +2617,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-44"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-44"></image>
         </p>
       </answer>
     </exercise>
@@ -2637,7 +2637,7 @@
         </p>
 
         <p>
-          <img src="figures/IntroTrigGraphics/TrigGraphs-45"/>
+          <image source="figures/IntroTrigGraphics/TrigGraphs-45"></image>
         </p>
       </answer>
     </exercise>


### PR DESCRIPTION
Convert image markup from HTML-style to PTX-style,
and delete some unnecessary latex.